### PR TITLE
1.7.3

### DIFF
--- a/src/app/build/erupt/components/tab-table/tab-table.component.html
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.html
@@ -12,7 +12,7 @@
 </ng-container>
 <st #st
     (change)="selectTableItem($event)"
-    [scroll]="{x:(tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 100) + 'px'}"
+    [scroll]="{x:(tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 130) + 'px'}"
     [size]="'small'"
     [columns]="column"
     [ps]="20"

--- a/src/app/build/erupt/service/data-handler.service.ts
+++ b/src/app/build/erupt/service/data-handler.service.ts
@@ -427,6 +427,7 @@ export class DataHandlerService {
         return eruptData;
     }
 
+
     //将后台数据转化成前端可视格式
     objectToEruptValue(object: any, eruptBuild: EruptBuildModel) {
         this.emptyEruptValue(eruptBuild);

--- a/src/app/build/erupt/service/data-handler.service.ts
+++ b/src/app/build/erupt/service/data-handler.service.ts
@@ -522,7 +522,7 @@ export class DataHandlerService {
                         }
                         break;
                     case EditType.CHOICE:
-                        edit.$value = isNotNull(object[field.fieldName]) && object[field.fieldName] + '';
+                        edit.$value = isNotNull(object[field.fieldName]) ? object[field.fieldName] + '' : null;
                         break;
                     case EditType.TAGS:
                         if (object[field.fieldName]) {
@@ -575,11 +575,11 @@ export class DataHandlerService {
             if (!ef.eruptFieldJson.edit) {
                 return;
             }
-            ef.eruptFieldJson.edit.$value = null;
             ef.eruptFieldJson.edit.$viewValue = null;
             ef.eruptFieldJson.edit.$tempValue = null;
             ef.eruptFieldJson.edit.$l_val = null;
             ef.eruptFieldJson.edit.$r_val = null;
+            ef.eruptFieldJson.edit.$value = null;
             switch (ef.eruptFieldJson.edit.type) {
                 case EditType.CHOICE:
                     if (eruptBuildModel.eruptModel.mode === "search") {

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -92,6 +92,7 @@ export class UiBuildService {
                         break;
                 }
             }
+
             obj.width = titleWidth;
             //展示类型
             switch (view.viewType) {

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -18,7 +18,6 @@ export class UiBuildService {
     }
 
 
-
     /**
      * 将view数据转换为alain table组件配置信息
      * @param eruptBuildModel ebm

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -91,8 +91,6 @@ export class UiBuildService {
                         break;
                 }
             }
-
-
             obj.width = titleWidth;
             //展示类型
             switch (view.viewType) {

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -92,6 +92,7 @@ export class UiBuildService {
                 }
             }
 
+
             obj.width = titleWidth;
             //展示类型
             switch (view.viewType) {

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -18,6 +18,7 @@ export class UiBuildService {
     }
 
 
+
     /**
      * 将view数据转换为alain table组件配置信息
      * @param eruptBuildModel ebm

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -17,6 +17,7 @@ export class UiBuildService {
         @Inject(NzMessageService) private msg: NzMessageService) {
     }
 
+
     /**
      * 将view数据转换为alain table组件配置信息
      * @param eruptBuildModel ebm

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -96,6 +96,7 @@ export class UiBuildService {
             //展示类型
             switch (view.viewType) {
                 case ViewType.TEXT:
+                    obj.className = "text-col";
                     obj.width = null;
                     break;
                 case ViewType.NUMBER:
@@ -479,7 +480,7 @@ export class UiBuildService {
                         this.modal.create({
                             nzWrapClassName: "modal-lg",
                             nzStyle: {top: "50px"},
-                            nzMaskClosable: true,
+                            nzMaskClosable: false,
                             nzKeyboard: true,
                             nzFooter: null,
                             nzTitle: view.title,

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -19,14 +19,15 @@
 
                         <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.delete">
                             <button nz-button nzType="danger" [nzGhost]="true" style="background: #fff !important;"
-                                    class="mb-sm" [nzLoading]="deleting"  id="erupt-btn-delete"
+                                    class="mb-sm" [nzLoading]="deleting" id="erupt-btn-delete"
                                     (click)="delRows()">
                                 <i nz-icon nzType="delete" nzTheme="outline"></i>删除
                             </button>
                         </ng-container>
 
                         <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.export">
-                            <button nz-button nzType="default" class="mb-sm" (click)="exportExcel()"  id="erupt-btn-export">
+                            <button nz-button nzType="default" class="mb-sm" (click)="exportExcel()"
+                                    id="erupt-btn-export">
                                 <i nz-icon nzType="download" nzTheme="outline"></i>下载
                             </button>
                         </ng-container>
@@ -34,7 +35,7 @@
                         <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.importable">
                             &nbsp;
                             <nz-button-group>
-                                <button nz-button (click)="importableExcel()"  id="erupt-btn-importable">
+                                <button nz-button (click)="importableExcel()" id="erupt-btn-importable">
                                     <i nz-icon nzType="import" nzTheme="outline"></i> &nbsp;导入
                                 </button>
                                 <button nz-button nz-dropdown [nzDropdownMenu]="menu1" nzPlacement="bottomRight">
@@ -53,7 +54,7 @@
 
                         <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.query">
                             <button nz-button nzType="primary" style="background: #fff !important;" [nzGhost]="true"
-                                    class="mb-sm" [nzLoading]="st._loading"  id="erupt-btn-query"
+                                    class="mb-sm" [nzLoading]="st._loading" id="erupt-btn-query"
                                     (click)="query()">
                                 <i nz-icon nzType="search" nzTheme="outline"></i>查询
                             </button>
@@ -83,7 +84,7 @@
                         <button class="mb-sm" nz-button (click)="hideCondition=!hideCondition">
                             <i nz-icon [nzType]="hideCondition?'caret-down':'caret-up'" nzTheme="outline"></i>
                         </button>
-                        <button class="mb-sm" nz-button (click)="clearCondition()"  id="erupt-btn-reset">
+                        <button class="mb-sm" nz-button (click)="clearCondition()" id="erupt-btn-reset">
                             <i nz-icon nzType="sync" nzTheme="outline"></i>重置
                         </button>
                     </div>
@@ -116,6 +117,7 @@
                     </erupt-edit-type>
                 </nz-card>
                 <st #st
+                    [widthMode]="{strictBehavior:'wrap'}"
                     [data]="stConfig.url" [columns]="columns"
                     [scroll]="{x: (clientWidth > 768 ? eruptBuildModel.eruptModel.tableColumns.length * 150 : 0) + 'px'}"
                     (change)="tableDataChange($event)"

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -444,6 +444,7 @@ export class TableComponent implements OnInit {
         }
     }
 
+
     //新增
     addRow() {
         const modal = this.modal.create({

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -432,6 +432,7 @@ export class TableComponent implements OnInit {
                 this.modal.confirm({
                     nzTitle: ro.title,
                     nzContent: "请确认是否执行此操作",
+                    nzCancelText: "关闭",
                     nzOnOk: async () => {
                         this.selectedRows = [];
                         await this.dataService.execOperatorFun(this.eruptBuildModel.eruptModel.eruptName, code, ids, null)

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -393,7 +393,7 @@ export class TableComponent implements OnInit {
                     url: url
                 }
             });
-        } else {
+        } else if (ro.type === OperationType.ERUPT) {
             let operationErupt = null;
             if (this.eruptBuildModel.operationErupts) {
                 operationErupt = this.eruptBuildModel.operationErupts[code];
@@ -403,17 +403,19 @@ export class TableComponent implements OnInit {
                     nzKeyboard: false,
                     nzTitle: ro.title,
                     nzMaskClosable: false,
-                    nzCancelText: "取消",
+                    nzCancelText: "关闭",
                     nzWrapClassName: "modal-lg",
                     nzOnOk: async () => {
                         modal.getInstance().nzCancelDisabled = true;
                         let eruptValue = this.dataHandler.eruptValueToObject({eruptModel: operationErupt});
                         let res = await this.dataService.execOperatorFun(eruptModel.eruptName, code, ids, eruptValue).toPromise().then(res => res);
                         modal.getInstance().nzCancelDisabled = false;
-
                         this.selectedRows = [];
                         if (res.status === Status.SUCCESS) {
                             this.st.reload();
+                            if (res.data) {
+                                eval(res.data);
+                            }
                             return true;
                         } else {
                             return false;
@@ -435,9 +437,12 @@ export class TableComponent implements OnInit {
                     nzCancelText: "关闭",
                     nzOnOk: async () => {
                         this.selectedRows = [];
-                        await this.dataService.execOperatorFun(this.eruptBuildModel.eruptModel.eruptName, code, ids, null)
+                        let res = await this.dataService.execOperatorFun(this.eruptBuildModel.eruptModel.eruptName, code, ids, null)
                             .toPromise().then();
                         this.st.reload();
+                        if (res.data) {
+                            eval(res.data);
+                        }
                     }
                 });
             }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -52,7 +52,9 @@ export class DataService {
     }
 
     static downloadAttachment(path: string): string {
-        if (WindowModel.fileDomain) {
+        if (path && (path.startsWith("http://") || path.startsWith("https://"))) {
+            return path;
+        } else if (WindowModel.fileDomain) {
             return WindowModel.fileDomain + path;
         } else {
             return RestPath.file + "/download-attachment" + path;
@@ -60,7 +62,9 @@ export class DataService {
     }
 
     static previewAttachment(path: string): string {
-        if (WindowModel.fileDomain) {
+        if (path && (path.startsWith("http://") || path.startsWith("https://"))) {
+            return path;
+        } else if (WindowModel.fileDomain) {
             return WindowModel.fileDomain + path;
         } else {
             return RestPath.eruptAttachment + path;

--- a/src/assets/alain-default.less
+++ b/src/assets/alain-default.less
@@ -25801,7 +25801,7 @@ g2-tag-cloud {
     text-align: center;
   }
   .text-col{
-    max-width: 220px;
+    max-width: 320px;
   }
 }
 

--- a/src/assets/alain-default.less
+++ b/src/assets/alain-default.less
@@ -25800,6 +25800,9 @@ g2-tag-cloud {
     min-width: 120px;
     text-align: center;
   }
+  .text-col{
+    max-width: 220px;
+  }
 }
 
 nz-input-group {

--- a/src/assets/alain-default.less
+++ b/src/assets/alain-default.less
@@ -25868,6 +25868,24 @@ reuse-tab ~ app-tpl .page-container {
   }
 }
 
+//::-webkit-scrollbar {
+//  width: 6px;
+//  height: 7px;
+//  background-color: rgba(0, 0, 0, 0);
+//  -ms-overflow-style: -ms-autohiding-scrollbar;
+//}
+//
+//::-webkit-scrollbar-thumb {
+//  border-radius: 5px;
+//  background-color: #ddd;
+//}
+//
+//
+//::-webkit-scrollbar-track {
+//  border-radius: 0;
+//  background-color: rgba(0, 0, 0, 0);
+//}
+
 //iframe page-container style end
 
 span.ripple {

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -31,6 +31,9 @@
     min-width: 120px;
     text-align: center;
   }
+  .text-col{
+    max-width: 220px;
+  }
 }
 
 nz-input-group {
@@ -100,5 +103,24 @@ reuse-tab ~ app-tpl .page-container {
     top: 40px;
   }
 }
+
+//::-webkit-scrollbar {
+//  width: 6px;
+//  height: 7px;
+//  background-color: rgba(0, 0, 0, 0);
+//  -ms-overflow-style: -ms-autohiding-scrollbar;
+//}
+//
+//::-webkit-scrollbar-thumb {
+//  border-radius: 5px;
+//  background-color: #ddd;
+//}
+//
+//
+//::-webkit-scrollbar-track {
+//  border-radius: 0;
+//  background-color: rgba(0, 0, 0, 0);
+//}
+
 
 //iframe page-container style end

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -36,7 +36,6 @@
   }
 }
 
-
 nz-input-group {
   width: 100%;
 }

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -36,6 +36,7 @@
   }
 }
 
+
 nz-input-group {
   width: 100%;
 }

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -32,7 +32,7 @@
     text-align: center;
   }
   .text-col{
-    max-width: 220px;
+    max-width: 320px;
   }
 }
 


### PR DESCRIPTION
🐞 修复树视图下 choice 组件数据不自动清空的 bug
🐞 修复EruptUser对象与EruptRole对象在编辑查看于修改时偶尔出现错误得bug
🐞 修复oracle数据源 EruptOperateLog 表无法自动创建的bug 
🐞 修复获取当前用户信息后，数据转变为游离状态的bug
🧩 关闭一对多弹出层点击框外就自动关闭能力
🧩 优化 erupt-monitor 手机端布局
🧩 优化 tab_table 组件滑动条出现的最大宽度
🧩 限制 table 表格最大宽度
🧩 优化审计数据的用户关联对象，EruptUser对象替换为数据结构更简单的EruptUserVo对象
🧩 magic-api升级至1.3.3
🌟 view注解附件与图片支持全路径网络资源的展示
🌟 多数据源支持自动建表，支持jpa额外配置项
🌟 @RowOperation 注解新增后置JS表达式执行，实现OperationHandler接口，afterJS方法即可