### PR TITLE
1.9.1

### DIFF
--- a/src/app/build/bi/bi/bi.component.html
+++ b/src/app/build/bi/bi/bi.component.html
@@ -19,7 +19,7 @@
             </button>
         </ng-container>
         <ng-container *ngIf="bi.export">
-            <button nz-button class="mb-sm" (click)="exportBiData()">
+            <button nz-button class="mb-sm" (click)="exportBiData()" [nzLoading]="downloading">
                 <i nz-icon nzType="download" nzTheme="outline"></i>{{'table.download'|i18n}}
             </button>
         </ng-container>

--- a/src/app/build/bi/bi/bi.component.ts
+++ b/src/app/build/bi/bi/bi.component.ts
@@ -50,6 +50,8 @@ export class BiComponent implements OnInit, OnDestroy {
 
     timer: NodeJS.Timer;
 
+    downloading: boolean = false;
+
     constructor(private dataService: BiDataService,
                 public route: ActivatedRoute,
                 private handlerService: HandlerService,
@@ -160,8 +162,12 @@ export class BiComponent implements OnInit, OnDestroy {
         if (!param) {
             return;
         }
-        this.dataService.exportExcel(this.bi.id, this.bi.code, param);
+        this.downloading = true;
+        this.dataService.exportExcel(this.bi.id, this.bi.code, param, () => {
+            this.downloading = false;
+        });
     }
+
 
     ngOnDestroy(): void {
         this.router$.unsubscribe();

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -2,7 +2,7 @@
     <nz-card [nzTitle]="chart.name" nzSize="small" [nzBodyStyle]="{padding:'0'}" [nzHoverable]="true"
              [nzExtra]="extraTemplate">
         <ng-container *ngIf="chart.type==chartType.tpl">
-            <erupt-iframe [url]="src" [height]="chart.height+'px'"></erupt-iframe>
+            <erupt-iframe [url]="src" [style]="{height:chart.height+'px',paddingTop:'1px'}"></erupt-iframe>
         </ng-container>
         <ng-container *ngIf="chart.type!=chartType.tpl">
             <div [id]='chart.code' style='width:100%;' [ngStyle]="{height:chart.height+'px'}"></div>

--- a/src/app/build/erupt/components/tab-table/tab-table.component.ts
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.ts
@@ -52,7 +52,9 @@ export class TabTableComponent implements OnInit {
 
     ngOnInit() {
         this.stConfig.stPage.front = true;
-        if (!this.tabErupt.eruptFieldModel.eruptFieldJson.edit.$value) {
+        if (this.tabErupt.eruptFieldModel.eruptFieldJson.edit.$value) {
+
+        } else {
             this.tabErupt.eruptFieldModel.eruptFieldJson.edit.$value = [];
         }
         if (this.onlyRead) {

--- a/src/app/build/erupt/components/tab-table/tab-table.component.ts
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.ts
@@ -90,9 +90,9 @@ export class TabTableComponent implements OnInit {
                             },
                             nzOnOk: async () => {
                                 let obj = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
-
                                 let result = await this.dataService.eruptDataValidate(this.tabErupt.eruptBuildModel.eruptModel.eruptName
                                     , obj, this.eruptBuildModel.eruptModel.eruptName).toPromise().then(resp => resp);
+                                this.objToLine(obj);
                                 if (result.status == Status.SUCCESS) {
                                     let $value = this.tabErupt.eruptFieldModel.eruptFieldJson.edit.$value;
                                     $value.forEach((val, index) => {
@@ -158,12 +158,13 @@ export class TabTableComponent implements OnInit {
                     parentEruptName: this.eruptBuildModel.eruptModel.eruptName
                 },
                 nzOnOk: async () => {
-                    let obj = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
+                    let obj: any = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
                     let result = await this.dataService.eruptDataValidate(this.tabErupt.eruptBuildModel.eruptModel.eruptName
                         , obj, this.eruptBuildModel.eruptModel.eruptName).toPromise().then(resp => resp);
                     if (result.status == Status.SUCCESS) {
                         obj[this.tabErupt.eruptBuildModel.eruptModel.eruptJson.primaryKeyCol] = -Math.floor(Math.random() * 1000);
                         let edit = this.tabErupt.eruptFieldModel.eruptFieldJson.edit;
+                        this.objToLine(obj);
                         if (!edit.$value) {
                             edit.$value = [];
                         }
@@ -237,6 +238,17 @@ export class TabTableComponent implements OnInit {
                 this.st.reload();
             }
         });
+    }
+
+
+    objToLine(obj: any) {
+        for (let key in obj) {
+            if (typeof obj[key] === 'object') {
+                for (let ii in <any>obj[key]) {
+                    obj[key + "_" + ii] = obj[key][ii];
+                }
+            }
+        }
     }
 
     selectTableItem(event) {

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -83,3 +83,14 @@ export interface Power {
     importable: boolean;
     export: boolean;
 }
+
+export interface Row {
+    color: string;
+    columns: Column[];
+}
+
+export interface Column {
+    style: string;
+    value: string;
+    colspan: number;
+}

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -27,7 +27,7 @@
 
                         <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.export">
                             <button nz-button nzType="default" class="mb-sm" (click)="exportExcel()"
-                                    id="erupt-btn-export">
+                                    id="erupt-btn-export" [nzLoading]="downloading">
                                 <i nz-icon nzType="download" nzTheme="outline"></i>{{'table.download'|translate}}
                             </button>
                         </ng-container>
@@ -131,13 +131,13 @@
                     [size]="'middle'"
                     [body]="bodyTpl">
                     <ng-template #bodyTpl>
-<!--                        <ng-container>-->
-<!--                            <tr>-->
-<!--                                <td colspan="3">性别平均值</td>-->
-<!--                                <td>{{ s }}</td>-->
-<!--                                <td colspan="5"></td>-->
-<!--                            </tr>-->
-<!--                        </ng-container>-->
+                        <!--                        <ng-container>-->
+                        <!--                            <tr>-->
+                        <!--                                <td colspan="3">性别平均值</td>-->
+                        <!--                                <td>{{ s }}</td>-->
+                        <!--                                <td colspan="5"></td>-->
+                        <!--                            </tr>-->
+                        <!--                        </ng-container>-->
                     </ng-template>
                 </st>
             </ng-container>

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -128,26 +128,17 @@
                     [multiSort]="stConfig.multiSort"
                     [page]="stConfig.stPage"
                     [req]="stConfig.req"
-                    [size]="'middle'">
-<!--                    <ng-template #bodyTpl let-s>-->
+                    [size]="'middle'"
+                    [body]="bodyTpl">
+                    <ng-template #bodyTpl>
 <!--                        <ng-container>-->
 <!--                            <tr>-->
-<!--                                <td>合计</td>-->
-<!--                                <td>{{ s }} 个</td>-->
-<!--                                <td>{{ s }}</td>-->
-<!--                                <td class="text-right">{{ s }}</td>-->
-<!--                                <td class="text-right">{{ s }}</td>-->
-<!--                                <td class="text-right">{{ s }}</td>-->
-<!--                                <td class="text-right">{{ s }}</td>-->
-<!--                                <td class="text-right">{{ s }}</td>-->
-<!--                            </tr>-->
-<!--                            <tr class="bg-grey-lighter">-->
 <!--                                <td colspan="3">性别平均值</td>-->
-<!--                                <td class="text-right">{{ s  }}</td>-->
-<!--                                <td colspan="4"></td>-->
+<!--                                <td>{{ s }}</td>-->
+<!--                                <td colspan="5"></td>-->
 <!--                            </tr>-->
 <!--                        </ng-container>-->
-<!--                    </ng-template>-->
+                    </ng-template>
                 </st>
             </ng-container>
         </div>

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -76,6 +76,8 @@ export class TableComponent implements OnInit {
 
     showTable: boolean = true;
 
+    downloading: boolean = false;
+
     _drill: { erupt: string, code: string, eruptParent: string, val: any };
 
 
@@ -593,7 +595,10 @@ export class TableComponent implements OnInit {
         }
         // this._drill.val
         //导出接口
-        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition);
+        this.downloading = true;
+        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition, () => {
+            this.downloading = false;
+        });
     }
 
 

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -588,8 +588,9 @@ export class TableComponent implements OnInit {
                 eruptModel: this.searchErupt
             }));
         }
+        // this._drill.val
         //导出接口
-        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition);
+        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition,);
     }
 
 

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -304,6 +304,8 @@ export class TableComponent implements OnInit {
                 let text = "";
                 if (ro.icon) {
                     text = `<i class=\"${ro.icon}\"></i>`;
+                } else {
+                    text = ro.title;
                 }
                 tableOperators.push({
                     type: 'link',
@@ -366,7 +368,7 @@ export class TableComponent implements OnInit {
     }
 
     /**
-     *  自定义功能触发
+     * 自定义功能触发
      * @param rowOperation 行按钮对象
      * @param data 数据（单个执行时使用）
      */

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -592,7 +592,7 @@ export class TableComponent implements OnInit {
         }
         // this._drill.val
         //导出接口
-        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition,);
+        this.dataService.downloadExcel(this.eruptBuildModel.eruptModel.eruptName, condition);
     }
 
 

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -314,6 +314,7 @@ export class TableComponent implements OnInit {
                     click: (record: any, modal: any) => {
                         that.createOperator(ro, record);
                     },
+                    iifBehavior: 'disabled',
                     iif: (item) => {
                         if (ro.ifExpr) {
                             return eval(ro.ifExpr);

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -119,7 +119,7 @@ export class I18NService implements AlainI18NService {
         const item = LANGS[lang];
         registerLocaleData(item.ng);
         this.nzI18nService.setLocale(item.zorro);
-        this.nzI18nService.setDateLocale(item.dateFns);
+        // this.nzI18nService.setDateLocale(item.dateFns);
         (window as any).__locale__ = item.dateFns;
         this.delonLocaleService.setLocale(item.delon);
     }

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -109,7 +109,6 @@ export class StartupService {
                             langData[key] = extra[key];
                         }
                     }
-                    console.log(langData);
                     this.translate.setTranslation(this.i18n.defaultLang, langData);
                     this.translate.setDefaultLang(this.i18n.defaultLang);
                 },

--- a/src/app/shared/component/iframe.component.ts
+++ b/src/app/shared/component/iframe.component.ts
@@ -5,7 +5,7 @@ import {IframeHeight} from "@shared/util/window.util";
     selector: 'erupt-iframe',
     template: `
         <nz-spin [nzSpinning]="spin">
-            <iframe [src]="url|safeUrl" style="width: 100%;border: 0;display: block" [ngStyle]="{height:height}"
+            <iframe [src]="url|safeUrl" style="width: 100%;border: 0;display: block" [ngStyle]="style"
                     (load)="iframeHeight($event)">
 
             </iframe>
@@ -18,6 +18,8 @@ export class EruptIframeComponent implements OnInit, OnChanges {
     @Input() url: string;
 
     @Input() height: string;
+
+    @Input() style: object = {};
 
     spin: boolean = true;
 
@@ -37,7 +39,7 @@ export class EruptIframeComponent implements OnInit, OnChanges {
     };
 
     ngOnChanges(changes: import("@angular/core").SimpleChanges): void {
-        console.log(changes.url.firstChange)
+        console.log(changes.url.firstChange);
         if (!changes.url.firstChange) {
             this.spin = true;
         }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -1,5 +1,5 @@
 import {Inject, Injectable} from "@angular/core";
-import {HttpClient} from "@angular/common/http";
+import {HttpClient, HttpEvent} from "@angular/common/http";
 import {Checkbox, Tree} from "../../build/erupt/model/erupt.model";
 import {_HttpClient, ALAIN_I18N_TOKEN} from "@delon/theme";
 import {Observable} from "rxjs";
@@ -12,6 +12,7 @@ import {WindowModel} from "@shared/model/window.model";
 import {MenuVo} from "@shared/model/erupt-menu";
 import {VL} from "../../build/erupt/model/erupt-field.model";
 import {I18NService} from "@core";
+import {downloadFile} from "@shared/util/erupt.util";
 
 @Injectable()
 export class DataService {
@@ -344,12 +345,37 @@ export class DataService {
         DataService.postExcelFile(RestPath.excel + "/template/" + eruptName + "?" + this.createAuthParam(eruptName));
     }
 
-    downloadExcel(eruptName: string, condition: any) {
+    downloadExcel2(eruptName: string, condition: any) {
         let param: any = {};
         if (condition) {
             param.condition = encodeURIComponent(JSON.stringify(condition));
         }
         DataService.postExcelFile(RestPath.excel + "/export/" + eruptName + "?" + this.createAuthParam(eruptName), param);
+    }
+
+    downloadExcel(eruptName: string, condition: any, callback) {
+        this._http.post(RestPath.excel + "/export/" + eruptName, condition, null, {
+            responseType: "arraybuffer",
+            observe: 'events',
+            headers: {
+                erupt: eruptName,
+                ...this.getCommonHeader()
+            }
+        }).subscribe((res) => {
+            if (res.type !== 4) {
+                // 还没准备好，无需处理
+                return;
+            }
+            downloadFile(res);
+            callback();
+        }, () => {
+            callback();
+        });
+        // let param: any = {};
+        // if (condition) {
+        //     param.condition = encodeURIComponent(JSON.stringify(condition));
+        // }
+        // DataService.postExcelFile(RestPath.excel + "/export/" + eruptName + "?" + this.createAuthParam(eruptName), param);
     }
 
     createAuthParam(eruptName: string): string {

--- a/src/app/shared/util/erupt.util.ts
+++ b/src/app/shared/util/erupt.util.ts
@@ -4,6 +4,7 @@
  * @param menuValue 菜单值
  */
 import {MenuTypeEnum} from "@shared/model/erupt-menu";
+import {HttpEvent} from "@angular/common/http";
 
 export function generateMenuPath(type: string, value: string) {
     let menuValue = value || '';
@@ -29,6 +30,20 @@ export function generateMenuPath(type: string, value: string) {
                 return "/fill/" + menuValue;
             }
     }
+}
+
+
+export function downloadFile(res: HttpEvent<any>) {
+    // @ts-ignore
+    let url = window.URL.createObjectURL(new Blob([res.body]));
+    let link = document.createElement("a");
+    link.style.display = "none";
+    link.href = url;
+    // @ts-ignore
+    link.setAttribute("download", decodeURIComponent(res.headers.get('Content-Disposition').split(';')[1].split('=')[1]));
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
 }
 
 


### PR DESCRIPTION
🐞 修复操作日志表oracle兼容问题
🐞 修复lookerSelf清除了查询条件的bug
🐞 修复 bi 自定义图表缺少分割线样式的问题
🧩 美化excel导出默认列宽
🧩 操作日志请求体json格式化显示
🌟 升级spring boot至2.6.0
🌟 增加日语支持
🌟 开源erupt-i18n
🌟 升级magic-api至1.7.0
🌟 bi支持图表sql历史记录功能
🌟 erupt-tpl增加 enjoy 模板引擎的支持 ，感谢icefairy提供关键代码
🌟 修改excel下载调用机制，支持下载loading功能
🌟 自定义按钮ifExpr配置按钮状态不是隐藏而是禁用
🌟 修复一对多新增再次关联时前端不显示的bug，感谢 zaster 提供关键代码
🌟 修复view配置多级显示时查询结果不正确的缺陷（cross join），感谢zaster提供关键代码 #76
