### PR TITLE
1.10.8

### DIFF
--- a/http/mime.js
+++ b/http/mime.js
@@ -1,5 +1,5 @@
 /**
- * Created by roc on 11/6/18.
+ * Created by yuepeng on 11/6/18.
  */
 exports.type = {
   "*": "application/octet-stream",

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,12 @@ window.eruptSiteConfig = {
     amapKey: null,
     login: function (e) {
 
+    },
+    upload: function (eruptName, eruptFieldName) {
+        return {
+            url: "",
+            headers: {}
+        }
     }
 };
 

--- a/src/app/build/bi/bi.module.ts
+++ b/src/app/build/bi/bi.module.ts
@@ -11,9 +11,10 @@ import {ChoiceComponent} from './components/choice/choice.component';
 import {ReferenceComponent} from "./components/reference/reference.component";
 import {CascadeComponent} from './components/cascade/cascade.component';
 import { ChartTableComponent } from './chart-table/chart-table.component';
+import { DrillComponent } from './drill/drill.component';
 
 @NgModule({
-    declarations: [BiComponent, DimensionComponent, ReferenceComponent, ChartComponent, ChoiceComponent, CascadeComponent, ChartTableComponent],
+    declarations: [BiComponent, DimensionComponent, ReferenceComponent, ChartComponent, ChoiceComponent, CascadeComponent, ChartTableComponent, DrillComponent],
     imports: [
         CommonModule,
         BiRoutingModule,
@@ -23,7 +24,8 @@ import { ChartTableComponent } from './chart-table/chart-table.component';
         BiDataService
     ],
     entryComponents: [
-        ReferenceComponent
+        ReferenceComponent,
+        DrillComponent
     ]
 })
 export class BiModule {

--- a/src/app/build/bi/bi/bi.component.html
+++ b/src/app/build/bi/bi/bi.component.html
@@ -48,7 +48,7 @@
         </ng-container>
         <nz-card *ngIf="bi.dimensions.length>0" [nzHoverable]="true" style="margin-bottom: 12px;margin-top: 4px"
                  [hidden]="hideCondition" nzSize="small">
-            <dimension [bi]="bi"></dimension>
+            <bi-dimension [bi]="bi"></bi-dimension>
         </nz-card>
         <ng-container *ngIf="bi.charts.length>0">
             <div nz-row nzGutter="12">

--- a/src/app/build/bi/bi/bi.component.ts
+++ b/src/app/build/bi/bi/bi.component.ts
@@ -1,15 +1,16 @@
 import {Component, Inject, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {Bi, DimType, pageType} from "../model/bi.model";
-import {NzMessageService} from "ng-zorro-antd";
+import {NzMessageService, NzModalService} from "ng-zorro-antd";
 import {STColumn, STPage} from "@delon/abc/table/table.interfaces";
 import {BiDataService} from "../service/data.service";
 import {ActivatedRoute} from "@angular/router";
 import {Subscription} from "rxjs";
-import {STComponent, STData} from "@delon/abc";
+import {STComponent} from "@delon/abc";
 import {ChartComponent} from "../chart/chart.component";
 import {HandlerService} from "../service/handler.service";
 import {SettingsService} from "@delon/theme";
 import {isNotNull, isNull} from "@shared/util/erupt.util";
+import {DrillComponent} from "../drill/drill.component";
 
 @Component({
     selector: 'app-bi',
@@ -85,8 +86,8 @@ export class BiComponent implements OnInit, OnDestroy {
                 public route: ActivatedRoute,
                 private handlerService: HandlerService,
                 public settingSrv: SettingsService,
-                @Inject(NzMessageService)
-                private msg: NzMessageService
+                @Inject(NzMessageService) private msg: NzMessageService,
+                @Inject(NzModalService) private modal: NzModalService
     ) {
     }
 
@@ -177,6 +178,25 @@ export class BiComponent implements OnInit, OnDestroy {
                                 col.sort = {
                                     key: column.name,
                                     default: (this.sort.column == column.name) ? this.sort.direction : null
+                                };
+                            }
+                            if (column.drill) {
+                                col.type = "link";
+                                col.click = (row) => {
+                                    this.modal.create({
+                                        nzWrapClassName: "modal-lg",
+                                        nzKeyboard: false,
+                                        nzMaskClosable: false,
+                                        nzStyle: {top: "30px"},
+                                        nzTitle: column.name,
+                                        nzContent: DrillComponent,
+                                        nzComponentParams: {
+                                            drillCode: column.code,
+                                            bi: this.bi,
+                                            row: row
+                                        },
+                                        nzFooter: null
+                                    });
                                 };
                             }
                             this.biTable.columns.push(col);

--- a/src/app/build/bi/bi/bi.component.ts
+++ b/src/app/build/bi/bi/bi.component.ts
@@ -1,5 +1,5 @@
 import {Component, Inject, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {Bi, DimType, pageType} from "../model/bi.model";
+import {Bi, columnType, DimType, pageType} from "../model/bi.model";
 import {NzMessageService, NzModalService} from "ng-zorro-antd";
 import {STColumn, STPage} from "@delon/abc/table/table.interfaces";
 import {BiDataService} from "../service/data.service";
@@ -167,8 +167,8 @@ export class BiComponent implements OnInit, OnDestroy {
                             let col: STColumn = {
                                 title: column.name,
                                 index: column.name,
-                                className: "text-center",
                                 width: column.width,
+                                className: "text-center",
                                 show: true,
                                 iif: () => {
                                     return col.show;
@@ -180,7 +180,12 @@ export class BiComponent implements OnInit, OnDestroy {
                                     default: (this.sort.column == column.name) ? this.sort.direction : null
                                 };
                             }
-                            if (column.drill) {
+                            if (column.type == columnType.STRING) {
+                            } else if (column.type == columnType.NUMBER) {
+                                col.type = "number";
+                            } else if (column.type == columnType.DATE) {
+                                col.type = "date";
+                            } else if (column.type == columnType.DRILL) {
                                 col.type = "link";
                                 col.click = (row) => {
                                     this.modal.create({

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -18,11 +18,18 @@
                 </div>
             </ng-container>
             <ng-container *ngSwitchCase="chartType.Number">
-                <div style="padding: 16px;text-align: center">
-                    <nz-statistic
-                            [nzValue]="11123.28"
-                            [nzTitle]="data[0]"
-                    ></nz-statistic>
+                <div style="padding: 16px 16px 0;text-align: center;">
+                    <div sg-container="{{data.length}}">
+                        <ng-container *ngFor="let d of data">
+                            <sg>
+                                <nz-statistic style="margin-bottom: 16px;"
+                                              [nzValue]="d[dataKeys[0]]||0"
+                                              [nzTitle]="d[dataKeys[1]]"
+                                              [nzValueStyle]="this.chart.chartOption"
+                                ></nz-statistic>
+                            </sg>
+                        </ng-container>
+                    </div>
                 </div>
             </ng-container>
             <ng-container *ngSwitchDefault>

--- a/src/app/build/bi/chart/chart.component.ts
+++ b/src/app/build/bi/chart/chart.component.ts
@@ -30,6 +30,7 @@ import {HandlerService} from "../service/handler.service";
 @Component({
     selector: 'bi-chart',
     templateUrl: "./chart.component.html",
+    styleUrls: ['./chart.component.less'],
     styles: []
 })
 export class ChartComponent implements OnInit, OnDestroy {
@@ -48,7 +49,9 @@ export class ChartComponent implements OnInit, OnDestroy {
 
     src: string;
 
-    data: any[];
+    data: any[] = [];
+
+    dataKeys: string[] = [];
 
     constructor(private ref: ElementRef, private biDataService: BiDataService,
                 private handlerService: HandlerService,
@@ -56,6 +59,9 @@ export class ChartComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
+        if (this.chart.chartOption) {
+            this.chart.chartOption = JSON.parse(this.chart.chartOption);
+        }
         this.init();
     }
 
@@ -76,6 +82,9 @@ export class ChartComponent implements OnInit, OnDestroy {
             this.biDataService.getBiChart(this.bi.code, this.chart.id, param).subscribe(data => {
                 this.chart.loading = false;
                 if (this.chart.type == ChartType.table || this.chart.type == ChartType.Number) {
+                    if (data[0]) {
+                        this.dataKeys = Object.keys(data[0]);
+                    }
                     this.data = data;
                 } else {
                     let element = this.ref.nativeElement.querySelector("#" + this.chart.code);
@@ -147,7 +156,7 @@ export class ChartComponent implements OnInit, OnDestroy {
             // theme: 'dark',
         };
         if (this.chart.chartOption) {
-            Object.assign(props, JSON.parse(this.chart.chartOption));
+            Object.assign(props, this.chart.chartOption);
         }
         switch (this.chart.type) {
             case ChartType.Line:

--- a/src/app/build/bi/dimension/dimension.component.html
+++ b/src/app/build/bi/dimension/dimension.component.html
@@ -112,6 +112,7 @@
                                 <ng-container *ngSwitchCase="dimType.DATE_RANGE">
                                     <nz-range-picker class="full-width"
                                                      [(ngModel)]="dim.$value"
+                                                     [nzRanges]="dateRanges"
                                                      [name]="dim.code" nzShowToday>
                                     </nz-range-picker>
                                 </ng-container>
@@ -131,6 +132,7 @@
                                     <nz-range-picker class="full-width"
                                                      [(ngModel)]="dim.$value"
                                                      [name]="dim.code"
+                                                     [nzRanges]="dateRanges"
                                                      nzShowToday
                                                      nzShowTime>
                                     </nz-range-picker>

--- a/src/app/build/bi/dimension/dimension.component.ts
+++ b/src/app/build/bi/dimension/dimension.component.ts
@@ -3,12 +3,14 @@ import {Bi, Dimension, DimType} from "../model/bi.model";
 import {colRules} from "@shared/model/util.model";
 import {NzModalService} from "ng-zorro-antd";
 import {ReferenceComponent} from "../components/reference/reference.component";
-import {DA_SERVICE_TOKEN, TokenService} from "@delon/auth";
+import {PresetRanges} from "ng-zorro-antd/date-picker/standard-types";
+import * as moment from 'moment';
+import {DatePipe} from "@angular/common";
 import {ALAIN_I18N_TOKEN} from "@delon/theme";
 import {I18NService} from "@core";
 
 @Component({
-    selector: 'dimension',
+    selector: 'bi-dimension',
     templateUrl: './dimension.component.html',
     styleUrls: ['./dimension.component.less'],
     styles: []
@@ -21,11 +23,24 @@ export class DimensionComponent implements OnInit {
 
     dimType = DimType;
 
-    constructor(@Inject(NzModalService) private modal: NzModalService) {
+    dateRanges: PresetRanges = {};
+
+    private datePipe: DatePipe = new DatePipe("zh-cn");
+
+    constructor(@Inject(NzModalService) private modal: NzModalService, @Inject(ALAIN_I18N_TOKEN) private i18n: I18NService) {
     }
 
     ngOnInit() {
-
+        let obj = {};
+        obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj['本周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj['上周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj['本月'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj['上月'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        this.dateRanges = obj;
     }
 
     ref(dim: Dimension) {

--- a/src/app/build/bi/dimension/dimension.component.ts
+++ b/src/app/build/bi/dimension/dimension.component.ts
@@ -31,19 +31,15 @@ export class DimensionComponent implements OnInit {
     }
 
     ngOnInit() {
-        let obj = {};
-        obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-
-        console.log(this.datePipe.transform(moment().add(-1, 'weeks').startOf('weeks').toDate(), "yyyy-MM-dd 00:00:00"));
-        console.log(this.datePipe.transform(moment().add(-1, 'weeks').endOf('weeks').toDate(), "yyyy-MM-dd 23:59:59"));
-        // obj['本周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        // obj['上周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['本月'] = [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['上月'] = [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")];
-        // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        this.dateRanges = obj;
+        this.dateRanges =  <any>{
+            [this.i18n.fanyi("global.today")]: [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            近7天: [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            近30天: [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            本月: [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            上月: [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")]
+            // obj['本周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+            // obj['上周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        };
     }
 
     ref(dim: Dimension) {

--- a/src/app/build/bi/dimension/dimension.component.ts
+++ b/src/app/build/bi/dimension/dimension.component.ts
@@ -33,12 +33,15 @@ export class DimensionComponent implements OnInit {
     ngOnInit() {
         let obj = {};
         obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        // obj['本周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        // obj['上周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        // obj['本月'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        // obj['上月'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+
+        console.log(this.datePipe.transform(moment().add(-1, 'weeks').startOf('weeks').toDate(), "yyyy-MM-dd 00:00:00"));
+        console.log(this.datePipe.transform(moment().add(-1, 'weeks').endOf('weeks').toDate(), "yyyy-MM-dd 23:59:59"));
+        // obj['本周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj['上周'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['本月'] = [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['上月'] = [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")];
         // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         this.dateRanges = obj;
     }

--- a/src/app/build/bi/drill/drill.component.html
+++ b/src/app/build/bi/drill/drill.component.html
@@ -1,0 +1,22 @@
+<ng-container *ngIf="biTable.columns&&biTable.columns.length>0">
+    <st [columns]="biTable.columns" [data]="biTable.data" #st
+        style="margin-bottom: 12px"
+        [loading]="querying"
+        [ps]="biTable.size"
+        [page]="biTable.page"
+        [scroll]="{x: (clientWidth > 768 ? biTable.columns.length * 150 : 0) + 'px'}"
+        [bordered]="settingSrv.layout.bordered"
+        [size]="'small'">
+    </st>
+    <nz-pagination style="text-align: center" nzShowSizeChanger nzShowQuickJumper
+                   [nzPageIndex]="biTable.index"
+                   [nzPageSize]="biTable.size"
+                   [nzTotal]="biTable.total"
+                   [nzPageSizeOptions]="biTable.page.pageSizes"
+                   [nzSize]="'small'"
+                   [nzShowTotal]="totalTemplate"
+    ></nz-pagination>
+    <!--(nzPageSizeChange)="pageSizeChange($event)"-->
+    <!--(nzPageIndexChange)="pageIndexChange($event)"-->
+    <ng-template #totalTemplate let-total>共{{ biTable.total }}条</ng-template>
+</ng-container>

--- a/src/app/build/bi/drill/drill.component.html
+++ b/src/app/build/bi/drill/drill.component.html
@@ -1,4 +1,9 @@
 <ng-container *ngIf="biTable.columns&&biTable.columns.length>0">
+<!--    <div style="text-align: right;margin-bottom: 16px">-->
+<!--        <button nz-button nzType="primary" [nzSize]="'small'">-->
+<!--            <i nz-icon nzType="download"></i>下载-->
+<!--        </button>-->
+<!--    </div>-->
     <st [columns]="biTable.columns" [data]="biTable.data" #st
         style="margin-bottom: 12px"
         [loading]="querying"
@@ -12,11 +17,11 @@
                    [nzPageIndex]="biTable.index"
                    [nzPageSize]="biTable.size"
                    [nzTotal]="biTable.total"
-                   [nzPageSizeOptions]="biTable.page.pageSizes"
+                   [nzPageSizeOptions]="this.bi.pageSizeOptions"
                    [nzSize]="'small'"
+                   (nzPageSizeChange)="pageSizeChange($event)"
+                   (nzPageIndexChange)="pageIndexChange($event)"
                    [nzShowTotal]="totalTemplate"
     ></nz-pagination>
-    <!--(nzPageSizeChange)="pageSizeChange($event)"-->
-    <!--(nzPageIndexChange)="pageIndexChange($event)"-->
     <ng-template #totalTemplate let-total>共{{ biTable.total }}条</ng-template>
 </ng-container>

--- a/src/app/build/bi/drill/drill.component.ts
+++ b/src/app/build/bi/drill/drill.component.ts
@@ -70,8 +70,12 @@ export class DrillComponent implements OnInit {
     }
 
     ngOnInit() {
-        // delete this.row._values;
-        this.dataService.getBiDrillData(this.bi.code, this.drillCode.toString(), 0, 10, this.row).subscribe(res => {
+        this.query(1, this.bi.pageSize);
+    }
+
+    query(pageIndex: number, pageSize: number) {
+        this.querying = true;
+        this.dataService.getBiDrillData(this.bi.code, this.drillCode.toString(), pageIndex, pageSize, this.row).subscribe(res => {
             this.querying = false;
             this.biTable.total = res.total;
             this.biTable.columns = [];
@@ -96,6 +100,15 @@ export class DrillComponent implements OnInit {
                 this.biTable.data = res.list;
             }
         });
+    }
+
+    pageIndexChange(index) {
+        this.query(index, this.biTable.size);
+    }
+
+    pageSizeChange(size) {
+        this.biTable.size = size;
+        this.query(1, size);
     }
 
 }

--- a/src/app/build/bi/drill/drill.component.ts
+++ b/src/app/build/bi/drill/drill.component.ts
@@ -70,6 +70,7 @@ export class DrillComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.biTable.size = this.bi.pageSize;
         this.query(1, this.bi.pageSize);
     }
 

--- a/src/app/build/bi/drill/drill.component.ts
+++ b/src/app/build/bi/drill/drill.component.ts
@@ -1,0 +1,101 @@
+import {Component, Inject, Input, OnInit, ViewChild} from '@angular/core';
+import {Bi} from "../model/bi.model";
+import {STColumn, STPage} from "@delon/abc/table/table.interfaces";
+import {BiDataService} from "../service/data.service";
+import {ActivatedRoute} from "@angular/router";
+import {HandlerService} from "../service/handler.service";
+import {SettingsService} from "@delon/theme";
+import {NzMessageService} from "ng-zorro-antd";
+import {STComponent} from "@delon/abc";
+
+@Component({
+    selector: 'erupt-drill',
+    templateUrl: './drill.component.html',
+    styles: []
+})
+export class DrillComponent implements OnInit {
+
+    @Input() bi: Bi;
+
+    @Input() drillCode: number;
+
+    @Input() row: any;
+
+    pageIndex: 0;
+
+    pageSize: 10;
+
+    name: string;
+
+    querying: boolean = false;
+
+    clientWidth = document.body.clientWidth;
+
+    biTable: {
+
+        data?: any,
+
+        columns?: STColumn[],
+
+        index: number;
+
+        size: number;
+
+        total: number;
+
+        page: STPage;
+
+        pageSizeOptions?: number[];
+
+    } = {
+        index: 1,
+
+        size: 10,
+
+        total: 0,
+
+        page: {
+            show: false
+        }
+
+    };
+
+    @ViewChild("st", {static: false}) st: STComponent;
+
+    constructor(private dataService: BiDataService,
+                public route: ActivatedRoute,
+                private handlerService: HandlerService,
+                public settingSrv: SettingsService,
+                @Inject(NzMessageService) private msg: NzMessageService) {
+    }
+
+    ngOnInit() {
+        // delete this.row._values;
+        this.dataService.getBiDrillData(this.bi.code, this.drillCode.toString(), 0, 10, this.row).subscribe(res => {
+            this.querying = false;
+            this.biTable.total = res.total;
+            this.biTable.columns = [];
+            if (!res.columns) {
+                this.biTable.data = [];
+            } else {
+                for (let column of res.columns) {
+                    if (column.display) {
+                        let col: STColumn = {
+                            title: column.name,
+                            index: column.name,
+                            className: "text-center",
+                            width: column.width,
+                            show: true,
+                            iif: () => {
+                                return col.show;
+                            }
+                        };
+                        this.biTable.columns.push(col);
+                    }
+                }
+                this.biTable.data = res.list;
+            }
+        });
+    }
+
+}

--- a/src/app/build/bi/model/bi.model.ts
+++ b/src/app/build/bi/model/bi.model.ts
@@ -112,7 +112,14 @@ export interface Column {
     width: number;
     sortable: boolean;
     display: boolean;
-    drill: boolean;
+    type: columnType;
+}
+
+export enum columnType {
+    STRING = "string",
+    NUMBER = 'number',
+    DATE = "date",
+    DRILL = 'drill'
 }
 
 export interface Reference {

--- a/src/app/build/bi/model/bi.model.ts
+++ b/src/app/build/bi/model/bi.model.ts
@@ -107,10 +107,12 @@ export interface BiData {
 }
 
 export interface Column {
+    code: number;
     name: string;
     width: number;
     sortable: boolean;
     display: boolean;
+    drill: boolean;
 }
 
 export interface Reference {

--- a/src/app/build/bi/service/data.service.ts
+++ b/src/app/build/bi/service/data.service.ts
@@ -44,6 +44,18 @@ export class BiDataService {
         });
     }
 
+    getBiDrillData(code: string, drillCode: string, pageIndex: number, pageSize: number, query: any): Observable<BiData> {
+        let params = {
+            pageIndex,
+            pageSize,
+        };
+        return this._http.post(RestPath.bi + "/drill/data/" + code + "/" + drillCode, query, params, {
+            headers: {
+                erupt: code
+            }
+        });
+    }
+
     //图表
     getBiChart(code: string, chartId: number, query: any): Observable<Map<String, any>[]> {
         return this._http.post(RestPath.bi + "/" + code + "/chart/" + chartId, query, null, {

--- a/src/app/build/bi/service/handler.service.ts
+++ b/src/app/build/bi/service/handler.service.ts
@@ -22,8 +22,8 @@ export class HandlerService {
             if (val) {
                 switch (dimension.type) {
                     case DimType.DATE_RANGE:
-                        val[0] = this.datePipe.transform(val[0], "yyyy-MM-dd");
-                        val[1] = this.datePipe.transform(val[1], "yyyy-MM-dd");
+                        val[0] = this.datePipe.transform(val[0], "yyyy-MM-dd 00:00:00");
+                        val[1] = this.datePipe.transform(val[1], "yyyy-MM-dd 23:59:59");
                         break;
                     case DimType.DATETIME_RANGE:
                         val[0] = this.datePipe.transform(val[0], "yyyy-MM-dd HH:mm:ss");

--- a/src/app/build/erupt/components/date/date.component.ts
+++ b/src/app/build/erupt/components/date/date.component.ts
@@ -41,14 +41,13 @@ export class DateComponent implements OnInit {
     ngOnInit() {
         this.startToday = moment(moment().format("yyyy-MM-DD 00:00:00")).toDate();
         this.endToday = moment(moment().format("yyyy-MM-DD 23:59:59")).toDate();
-        let obj = {};
-        obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['本月'] = [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        obj['上月'] = [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")];
-        // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
-        this.dateRanges = obj;
+        this.dateRanges = <any>{
+            [this.i18n.fanyi("global.today")]: [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            近7天: [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            近30天: [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            本月: [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            上月: [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")]
+        };
         this.edit = this.field.eruptFieldJson.edit;
     }
 

--- a/src/app/build/erupt/components/date/date.component.ts
+++ b/src/app/build/erupt/components/date/date.component.ts
@@ -2,7 +2,7 @@ import {Component, Inject, Input, OnInit} from '@angular/core';
 import {Edit, EruptFieldModel} from "../../model/erupt-field.model";
 import {DateEnum, PickerMode} from "../../model/erupt.enum";
 import {DatePipe} from "@angular/common";
-import {DisabledDateFn} from "ng-zorro-antd/date-picker/standard-types";
+import {DisabledDateFn, PresetRanges} from "ng-zorro-antd/date-picker/standard-types";
 import * as moment from 'moment';
 import {ALAIN_I18N_TOKEN} from "@delon/theme";
 import {I18NService} from "@core";
@@ -26,7 +26,7 @@ export class DateComponent implements OnInit {
 
     private datePipe: DatePipe = new DatePipe("zh-cn");
 
-    dateRanges: object = {};
+    dateRanges: PresetRanges = {};
 
     dateEnum = DateEnum;
 
@@ -43,6 +43,9 @@ export class DateComponent implements OnInit {
         this.endToday = moment(moment().format("yyyy-MM-DD 23:59:59")).toDate();
         let obj = {};
         obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         this.dateRanges = obj;
         this.edit = this.field.eruptFieldJson.edit;
     }

--- a/src/app/build/erupt/components/date/date.component.ts
+++ b/src/app/build/erupt/components/date/date.component.ts
@@ -45,6 +45,8 @@ export class DateComponent implements OnInit {
         obj[this.i18n.fanyi("global.today")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         obj['近7天'] = [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         obj['近30天'] = [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['本月'] = [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
+        obj['上月'] = [this.datePipe.transform(moment().add(-1, 'month').toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(moment().add(-1, 'month').endOf("month").toDate(), "yyyy-MM-dd 23:59:59")];
         // obj[this.i18n.fanyi("global.all")] = [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")];
         this.dateRanges = obj;
         this.edit = this.field.eruptFieldJson.edit;

--- a/src/app/build/erupt/components/edit-type/edit-type.component.html
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.html
@@ -431,6 +431,7 @@
                                     <ng-container [ngSwitch]="field.eruptFieldJson.edit.attachmentType.type">
                                         <ng-container *ngSwitchCase="attachmentEnum.IMAGE">
                                             <nz-upload nzListType="picture-card"
+                                                       [nzAccept]="['.bmp','.jpg','.jpeg','.png','.gif','.webp','.heic','.avif','.svg']"
                                                        [nzDisabled]="isReadonly(field)"
                                                        [nzMultiple]="false"
                                                        [(nzFileList)]="field.eruptFieldJson.edit.$viewValue"
@@ -447,6 +448,7 @@
                                         </ng-container>
                                         <ng-container *ngSwitchCase="attachmentEnum.BASE">
                                             <nz-upload nzType="drag" *ngIf="field.eruptFieldJson.edit.$viewValue"
+                                                       [nzAccept]="field.eruptFieldJson.edit.attachmentType.fileTypes"
                                                        [nzLimit]="field.eruptFieldJson.edit.attachmentType.maxLimit"
                                                        [nzDisabled]="isReadonly(field)||field.eruptFieldJson.edit.$viewValue.length==field.eruptFieldJson.edit.attachmentType.maxLimit"
                                                        (nzChange)="upLoadNzChange($event,field)"
@@ -518,7 +520,8 @@
                     <ng-container *ngSwitchCase="editType.TPL">
                         <div nz-col [nzSpan]="24">
                             <iframe [src]="dataService.getFieldTplPath(eruptBuildModel.eruptModel.eruptName,field.fieldName) | safeUrl"
-                                    style="width:100%;border: none;vertical-align: bottom;" (load)="iframeHeight($event)">
+                                    style="width:100%;border: none;vertical-align: bottom;"
+                                    (load)="iframeHeight($event)">
                             </iframe>
                         </div>
                     </ng-container>

--- a/src/app/build/erupt/components/edit-type/edit-type.component.ts
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.ts
@@ -77,6 +77,9 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
                 if (!edit.$viewValue) {
                     edit.$viewValue = [];
                 }
+                edit.attachmentType.fileTypes = edit.attachmentType.fileTypes.map(it => {
+                    return "." + it;
+                });
             }
             let showBy = model.eruptFieldJson.edit.showBy;
             if (showBy) {

--- a/src/app/build/erupt/components/excel-import/excel-import.component.html
+++ b/src/app/build/erupt/components/excel-import/excel-import.component.html
@@ -4,6 +4,7 @@
 <nz-alert *ngIf="errorText" style="margin-bottom: 8px;" nzType="error" nzCloseable [nzDescription]="errorText">
 </nz-alert>
 <nz-upload nzType="drag"
+           [nzAccept]="['.xls','.xlsx']"
            [(nzFileList)]="fileList"
            [nzLimit]="1"
            [nzHeaders]="{token:tokenService.get().token,erupt:eruptModel.eruptName}"

--- a/src/app/build/erupt/components/tab-table/tab-table.component.html
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.html
@@ -12,7 +12,7 @@
 </ng-container>
 <st #st
     (change)="selectTableItem($event)"
-    [scroll]="{x:(tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 130) + 'px'}"
+    [scroll]="{x: (clientWidth > 768 ? (tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 130) : 0) + 'px'}"
     [size]="'small'"
     [columns]="column"
     [ps]="20"

--- a/src/app/build/erupt/components/tab-table/tab-table.component.html
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.html
@@ -12,7 +12,7 @@
 </ng-container>
 <st #st
     (change)="selectTableItem($event)"
-    [scroll]="{x: (clientWidth > 768 ? (tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 130) : 0) + 'px'}"
+    [scroll]="{x: (clientWidth > 768 ? ((tabErupt.eruptBuildModel.eruptModel.tableColumns.length * 130) + 'px') : '460px')}"
     [size]="'small'"
     [columns]="column"
     [ps]="20"

--- a/src/app/build/erupt/components/tab-table/tab-table.component.ts
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.ts
@@ -36,6 +36,8 @@ export class TabTableComponent implements OnInit {
 
     @Input() onlyRead: boolean = false;
 
+    clientWidth = document.body.clientWidth;
+
     column: STColumn[];
 
     checkedRow = [];
@@ -90,7 +92,7 @@ export class TabTableComponent implements OnInit {
                             },
                             nzOnOk: async () => {
                                 let obj = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
-                                let result = await this.dataService.eruptTabUpdate(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptBuildModel.eruptModel.eruptName, obj)
+                                let result = await this.dataService.eruptTabUpdate(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptFieldModel.fieldName, obj)
                                     .toPromise().then(resp => resp);
                                 if (result.status == Status.SUCCESS) {
                                     obj = result.data;
@@ -160,7 +162,7 @@ export class TabTableComponent implements OnInit {
                 },
                 nzOnOk: async () => {
                     let obj: any = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
-                    let result = await this.dataService.eruptTabAdd(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptBuildModel.eruptModel.eruptName, obj).toPromise().then(resp => resp);
+                    let result = await this.dataService.eruptTabAdd(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptFieldModel.fieldName, obj).toPromise().then(resp => resp);
                     if (result.status == Status.SUCCESS) {
                         obj = result.data;
                         obj[this.tabErupt.eruptBuildModel.eruptModel.eruptJson.primaryKeyCol] = -Math.floor(Math.random() * 1000);

--- a/src/app/build/erupt/components/tab-table/tab-table.component.ts
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.ts
@@ -90,10 +90,11 @@ export class TabTableComponent implements OnInit {
                             },
                             nzOnOk: async () => {
                                 let obj = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
-                                let result = await this.dataService.eruptDataValidate(this.tabErupt.eruptBuildModel.eruptModel.eruptName
-                                    , obj, this.eruptBuildModel.eruptModel.eruptName).toPromise().then(resp => resp);
-                                this.objToLine(obj);
+                                let result = await this.dataService.eruptTabUpdate(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptBuildModel.eruptModel.eruptName, obj)
+                                    .toPromise().then(resp => resp);
                                 if (result.status == Status.SUCCESS) {
+                                    obj = result.data;
+                                    this.objToLine(obj);
                                     let $value = this.tabErupt.eruptFieldModel.eruptFieldJson.edit.$value;
                                     $value.forEach((val, index) => {
                                         let tabPrimaryKeyCol = this.tabErupt.eruptBuildModel.eruptModel.eruptJson.primaryKeyCol;
@@ -159,9 +160,9 @@ export class TabTableComponent implements OnInit {
                 },
                 nzOnOk: async () => {
                     let obj: any = this.dataHandlerService.eruptValueToObject(this.tabErupt.eruptBuildModel);
-                    let result = await this.dataService.eruptDataValidate(this.tabErupt.eruptBuildModel.eruptModel.eruptName
-                        , obj, this.eruptBuildModel.eruptModel.eruptName).toPromise().then(resp => resp);
+                    let result = await this.dataService.eruptTabAdd(this.eruptBuildModel.eruptModel.eruptName, this.tabErupt.eruptBuildModel.eruptModel.eruptName, obj).toPromise().then(resp => resp);
                     if (result.status == Status.SUCCESS) {
+                        obj = result.data;
                         obj[this.tabErupt.eruptBuildModel.eruptModel.eruptJson.primaryKeyCol] = -Math.floor(Math.random() * 1000);
                         let edit = this.tabErupt.eruptFieldModel.eruptFieldJson.edit;
                         this.objToLine(obj);

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -212,17 +212,8 @@ export class TableComponent implements OnInit {
             tableOperators.push({
                 icon: "eye",
                 click: (record: any, modal: any) => {
-                    // let eruptBuildModel = deepCopy(this.eruptBuildModel);
-                    // eruptBuildModel.eruptModel.eruptFieldModelMap = new Map<String, EruptFieldModel>();
-                    // eruptBuildModel.eruptModel.eruptFieldModels.forEach(field => {
-                    //     if (field.eruptFieldJson.edit) {
-                    //         field.eruptFieldJson.edit.readOnly.add = true;
-                    //         field.eruptFieldJson.edit.readOnly.edit = true;
-                    //     }
-                    //     eruptBuildModel.eruptModel.eruptFieldModelMap.set(field.fieldName, field);
-                    // });
                     this.modal.create({
-                        nzWrapClassName: "modal-lg",
+                        nzWrapClassName: "modal-lg edit-modal-lg",
                         nzStyle: {top: "60px"},
                         nzMaskClosable: true,
                         nzKeyboard: true,
@@ -245,7 +236,7 @@ export class TableComponent implements OnInit {
                 icon: "edit",
                 click: (record: any) => {
                     const model = this.modal.create({
-                        nzWrapClassName: "modal-lg",
+                        nzWrapClassName: "modal-lg edit-modal-lg",
                         nzStyle: {top: "60px"},
                         nzMaskClosable: false,
                         nzKeyboard: false,
@@ -473,7 +464,7 @@ export class TableComponent implements OnInit {
     addRow() {
         const modal = this.modal.create({
             nzStyle: {top: "60px"},
-            nzWrapClassName: "modal-lg",
+            nzWrapClassName: "modal-lg edit-modal-lg",
             nzMaskClosable: false,
             nzKeyboard: false,
             nzTitle: this.i18n.fanyi("global.new"),

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -49,7 +49,7 @@ export class StartupService {
             "                           \\/_/        ", "color:#2196f3;font-weight:800");
         console.log("%chttps://www.erupt.xyz", "color:#2196f3;font-size:1.3em;padding:16px 0;");
         console.groupEnd();
-
+        (window as any).eruptWebSuccess = true;
         await new Promise((resolve) => {
             let xhr = new XMLHttpRequest();
             xhr.open('GET', RestPath.eruptApp);
@@ -65,7 +65,6 @@ export class StartupService {
                 }
             };
         });
-
         //注入全局方法：token
         window[GlobalKeys.getAppToken] = () => {
             return this.tokenService.get();

--- a/src/app/routes/passport/login/login.component.ts
+++ b/src/app/routes/passport/login/login.component.ts
@@ -156,6 +156,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
                         this.modal.create({
                             nzTitle: this.i18n.fanyi("global.reset_pwd"),
                             nzMaskClosable: false,
+                            nzKeyboard: !EruptAppData.get().forceResetPwd,
+                            nzClosable: !EruptAppData.get().forceResetPwd,
                             nzContent: ChangePwdComponent,
                             nzFooter: null,
                             nzBodyStyle: {

--- a/src/app/shared/model/erupt-app.model.ts
+++ b/src/app/shared/model/erupt-app.model.ts
@@ -5,4 +5,5 @@ export interface EruptAppModel {
     hash: number;
     version: string;
     loginPagePath: string;
+    forceResetPwd: boolean;
 }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -329,6 +329,33 @@ export class DataService {
         });
     }
 
+    eruptTabAdd(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
+        return this._http.post(RestPath.dataModify + "/tab-add/" + eruptName + "/" + tabName, data, null, {
+            headers: {
+                erupt: eruptName,
+                ...this.getCommonHeader()
+            }
+        });
+    }
+
+    eruptTabUpdate(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
+        return this._http.post(RestPath.dataModify + "/tab-update/" + eruptName + "/" + tabName, data, null, {
+            headers: {
+                erupt: eruptName,
+                ...this.getCommonHeader()
+            }
+        });
+    }
+
+    eruptTabDelete(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
+        return this._http.post(RestPath.dataModify + "/tab-delete/" + eruptName + "/" + tabName, data, null, {
+            headers: {
+                erupt: eruptName,
+                ...this.getCommonHeader()
+            }
+        });
+    }
+
     //登录
     login(account: string, pwd: string, verifyCode?: any): Observable<LoginModel> {
         return this._http.post(RestPath.erupt + "/login", {}, {

--- a/src/assets/alain-default.less
+++ b/src/assets/alain-default.less
@@ -25853,6 +25853,12 @@ reuse-tab ~ app-tpl .page-container {
   top: @alain-default-header-hg + 40;
 }
 
+@media (min-width: 992px) {
+  .edit-modal-lg .ant-modal {
+    max-width: 935px !important;
+  }
+}
+
 @media screen and (max-width: 767px) {
   .page-container {
     height: calc(100vh - @alain-default-header-hg);

--- a/src/index.html
+++ b/src/index.html
@@ -77,13 +77,19 @@
             left: 0;
             right: 0;
             bottom: 26px;
-            animation: tipFadeIn 7s;
+            animation: tipFadeIn 5s;
         }
     </style>
     <link rel="stylesheet" href="assets/font-awesome/css/font-awesome.min.css">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#1976d2">
     <script>
+        //如果固定周期内未成功启动则重新刷新页面
+        window.setTimeout(function () {
+            if (!window.eruptWebSuccess){
+                location.reload(true)
+            }
+        }, 1000 * 10);
         (function (date) {
             var __t__ = '' + date.getFullYear() + date.getMonth() + date.getDate() + date.getHours() + date.getMinutes();
             document.write(

--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -86,6 +86,13 @@ reuse-tab ~ app-tpl .page-container {
   top: @alain-default-header-hg + 40;
 }
 
+@media (min-width: 992px) {
+  .edit-modal-lg .ant-modal {
+    max-width: 935px !important;
+  }
+}
+
+
 @media screen and (max-width: 767px) {
   .page-container {
     height: calc(100vh - @alain-default-header-hg);


### PR DESCRIPTION
🐞 修复window系统下本地图片下载失败的bug
🧩 菜单值更新后会重新构建权限 [#93](https://github.com/erupts/erupt/pull/93)
🧩 增加redis-session自动续期配置 [#18](https://gitee.com/erupt/erupt/pulls/18)
🧩 角色管理下可查看角下用户
🧩 EruptRole 表增加排序字段 sort
🧩 优化tab_add组件，修改和新增行为可触发dataProxy
🧩 增加时间区间组件快捷选择功能，支持近7天、近30天、本周、上周、本月、上月选择
🧩 Attachment组件支持文件类配置会后绑定UI，仅能选择已配置文件类型
🧩 excel导入配置限定文件类型为xls和xlsx
🌟 开源 erupt-tpl-ui element-plus
🌟 BI报表支持下钻功能
🌟 开源 erupt-cloud 用于分布式方式开发erupt node节点，构建通用云配置中心