### PR TITLE
1.10.10

### DIFF
--- a/src/app/build/erupt/components/checkbox/checkbox.component.html
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.html
@@ -1,7 +1,7 @@
 <nz-spin [nzSpinning]="loading">
     <nz-checkbox-wrapper style="width: 100%;" (nzOnChange)="change($event)">
         <div nz-row>
-            <div nz-col nzSpan="4" *ngFor="let c of checkbox">
+            <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="8" [nzLg]="4" *ngFor="let c of checkbox">
                 <label nz-checkbox [nzDisabled]="onlyRead" [nzValue]="c.id"
                        [nzChecked]="edit.$value&&edit.$value.indexOf(c.id)!=-1">{{c.label}}</label>
             </div>

--- a/src/app/build/tpl/tpl.component.ts
+++ b/src/app/build/tpl/tpl.component.ts
@@ -2,7 +2,7 @@ import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core
 import {DataService} from "@shared/service/data.service";
 import {Subscription} from "rxjs";
 import {ActivatedRoute, Router} from "@angular/router";
-import {MenuService, SettingsService} from "@delon/theme";
+import {SettingsService} from "@delon/theme";
 
 @Component({
     selector: 'app-tpl',
@@ -30,7 +30,7 @@ export class TplComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.router$ = this.route.params.subscribe((params) => {
-            this.name = this.router.url.replace("/tpl", "");
+            this.name = this.router.url.replace("/tpl/", "");
             this.url = this.dataService.getEruptTpl(this.name);
             if (this.renderType === 'micro-app') {
                 this.url = window.location.origin + window.location.pathname + this.url;

--- a/src/app/build/tpl/tpl.component.ts
+++ b/src/app/build/tpl/tpl.component.ts
@@ -1,7 +1,7 @@
 import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {DataService} from "@shared/service/data.service";
 import {Subscription} from "rxjs";
-import {ActivatedRoute} from "@angular/router";
+import {ActivatedRoute, Router} from "@angular/router";
 import {MenuService, SettingsService} from "@delon/theme";
 
 @Component({
@@ -24,13 +24,14 @@ export class TplComponent implements OnInit, OnDestroy {
 
     constructor(private dataService: DataService,
                 public settingSrv: SettingsService,
+                private router: Router,
                 public route: ActivatedRoute) {
     }
 
     ngOnInit() {
         this.router$ = this.route.params.subscribe((params) => {
-            this.name = params.name;
-            this.url = this.dataService.getEruptTpl(params.name, this.route.snapshot.fragment);
+            this.name = this.router.url.replace("/tpl", "");
+            this.url = this.dataService.getEruptTpl(this.name);
             if (this.renderType === 'micro-app') {
                 this.url = window.location.origin + window.location.pathname + this.url;
             }

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from "@angular/core";
-import {RouterModule, Routes} from "@angular/router";
+import {RouterModule, Routes, UrlSegment} from "@angular/router";
 import {environment} from "@env/environment";
 // layout
 import {LayoutDefaultComponent} from "../layout/default/default.component";
@@ -29,11 +29,10 @@ let coreRouter: Routes = [
         loadChildren: () => import( "../build/bi/bi.module").then(m => m.BiModule),
         pathMatch: "full"
     },
-    {
-        path: "tpl/:name",
-        loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule),
-        pathMatch: "full"
-    }
+    {path: "tpl/:name", pathMatch: "full", loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)},
+    {path: 'tpl/:name/:name1', pathMatch: "full", loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)},
+    {path: 'tpl/:name/:name2/:name3', pathMatch: "full", loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)},
+    {path: 'tpl/:name/:name2/:name3/:name4', pathMatch: "full", loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)}
 ];
 
 const routes: Routes = [

--- a/src/app/routes/site/site.component.ts
+++ b/src/app/routes/site/site.component.ts
@@ -26,7 +26,7 @@ export class SiteComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.router$ = this.route.params.subscribe((params) => {
             this.spin = true;
-            let url = atob(decodeURIComponent(params.url));
+            let url = decodeURIComponent(atob(params.url));
             url += (url.indexOf("?") === -1 ? "?" : "&") + "_token=" + this.tokenService.get().token;
             this.url = url;
         });

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -115,8 +115,8 @@ export class DataService {
         });
     }
 
-    getEruptTpl(name: string, query?: string) {
-        let params = "_token=" + this.tokenService.get().token + "&_lang=" + this.i18n.currentLang + "&_erupt=" + name + (query && ("&" + query));
+    getEruptTpl(name: string) {
+        let params = "_token=" + this.tokenService.get().token + "&_lang=" + this.i18n.currentLang;
         if (name.indexOf("?") == -1) {
             return RestPath.tpl + "/" + name + "?" + params;
         } else {

--- a/src/app/shared/util/erupt.util.ts
+++ b/src/app/shared/util/erupt.util.ts
@@ -16,13 +16,13 @@ export function generateMenuPath(type: string, value: string) {
         case MenuTypeEnum.bi:
             return "/bi/" + menuValue;
         case MenuTypeEnum.tpl:
-            return "/tpl/" + menuValue.replace("?", "#");
+            return "/tpl/" + menuValue;
         case MenuTypeEnum.router:
             return "/" + menuValue;
         case MenuTypeEnum.newWindow:
             return "/" + menuValue;
         case MenuTypeEnum.link:
-            return "/site/" + encodeURIComponent(window.btoa(menuValue));
+            return "/site/" + window.btoa(encodeURIComponent(menuValue));
         case MenuTypeEnum.fill:
             if (menuValue.startsWith("/")) {
                 return "/fill" + menuValue;


### PR DESCRIPTION
🐞 修复cloud模式下自定义按钮执行报错的bug
🐞 修复动态readonly调用方法不正确的bug
🐞 修复由于版本升级导致 cloud node 节点序列化错误的bug
🧩 增加服务结束时销毁job能力
🧩 checkbox组件在手机端展示更加友好
🧩 eruptNode节点出错不会影响这个页面的渲染
🧩 cloud监控页面展示node节点引用模块信息
🌟 自定义模板支持获取当前菜单能力
🌟 增加 erupt.init-method-enum 配置可选择性配置初始化方式
🌟 TPL模板支持路径模糊匹配能力，如：*/xxx.html 、xxx/**.html等匹配方式同spring mvc