### PR TITLE
1.10.14

### DIFF
--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -368,7 +368,7 @@ export class TableComponent implements OnInit {
             });
         }
         this.columns = _columns;
-        this.showColumnLength = this.eruptBuildModel.eruptModel.tableColumns.filter(e => e.show).length
+        this.showColumnLength = this.eruptBuildModel.eruptModel.tableColumns.filter(e => e.show).length;
     }
 
 
@@ -435,7 +435,11 @@ export class TableComponent implements OnInit {
                         this.selectedRows = [];
                         if (res.status === Status.SUCCESS) {
                             this.stLoad();
-                            res.data && eval(res.data);
+                            try {
+                                res.data && eval(res.data);
+                            } catch (e) {
+                                this.msg.error(e);
+                            }
                             return true;
                         } else {
                             return false;
@@ -461,7 +465,11 @@ export class TableComponent implements OnInit {
                             .toPromise().then();
                         this.stLoad();
                         if (res.data) {
-                            eval(res.data);
+                            try {
+                                eval(res.data);
+                            } catch (e) {
+                                this.msg.error(e);
+                            }
                         }
                     }
                 });

--- a/src/app/build/erupt/view/tree/tree.component.html
+++ b/src/app/build/erupt/view/tree/tree.component.html
@@ -50,7 +50,7 @@
                     <ng-container *ngIf="!selectLeaf">
                         <button nz-button (click)="add()" [disabled]="loading" id="erupt-btn-add-new"
                                 *ngIf="eruptBuildModel.eruptModel.eruptJson.power.add">
-                            <i nz-icon nzType="plus" theme="outline"></i>{{'tree.add'|translate}}
+                            <i nz-icon nzType="save" theme="outline"></i>{{'tree.add'|translate}}
                         </button>
                     </ng-container>
                 </div>

--- a/src/app/layout/default/default.component.ts
+++ b/src/app/layout/default/default.component.ts
@@ -185,6 +185,9 @@ export class LayoutDefaultComponent implements OnInit, AfterViewInit, OnDestroy 
                         if (menu.type == MenuTypeEnum.newWindow) {
                             option.target = "_blank";
                             option.externalLink = menu.value;
+                        } else if (menu.type == MenuTypeEnum.selfWindow) {
+                            option.target = "_self";
+                            option.externalLink = menu.value;
                         }
                         result.push(option);
                     }

--- a/src/app/routes/passport/login/login.component.ts
+++ b/src/app/routes/passport/login/login.component.ts
@@ -156,8 +156,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
                         this.modal.create({
                             nzTitle: this.i18n.fanyi("global.reset_pwd"),
                             nzMaskClosable: false,
-                            nzKeyboard: !EruptAppData.get().forceResetPwd,
-                            nzClosable: !EruptAppData.get().forceResetPwd,
+                            nzKeyboard: true,
+                            nzClosable: false,
                             nzContent: ChangePwdComponent,
                             nzFooter: null,
                             nzBodyStyle: {

--- a/src/app/routes/passport/login/login.component.ts
+++ b/src/app/routes/passport/login/login.component.ts
@@ -156,8 +156,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
                         this.modal.create({
                             nzTitle: this.i18n.fanyi("global.reset_pwd"),
                             nzMaskClosable: false,
-                            nzKeyboard: true,
                             nzClosable: false,
+                            nzKeyboard: true,
                             nzContent: ChangePwdComponent,
                             nzFooter: null,
                             nzBodyStyle: {

--- a/src/app/shared/model/erupt-app.model.ts
+++ b/src/app/shared/model/erupt-app.model.ts
@@ -5,5 +5,4 @@ export interface EruptAppModel {
     hash: number;
     version: string;
     loginPagePath: string;
-    forceResetPwd: boolean;
 }

--- a/src/app/shared/model/erupt-menu.ts
+++ b/src/app/shared/model/erupt-menu.ts
@@ -17,6 +17,7 @@ export enum MenuTypeEnum {
     api = "api",
     link = "link",
     newWindow = "newWindow",
+    selfWindow = "selfWindow",
     bi = "bi",
     tpl = "tpl",
 }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -357,7 +357,7 @@ export class DataService {
 
     //登录
     login(account: string, pwd: string, verifyCode?: any): Observable<LoginModel> {
-        return this._http.post(RestPath.erupt + "/login", {}, {
+        return this._http.get(RestPath.erupt + "/login", {
                 account: account,
                 pwd: pwd,
                 verifyCode: verifyCode

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -371,7 +371,7 @@ export class DataService {
 
 
     changePwd(account: string, pwd: string, newPwd: string, newPwd2: string): Observable<EruptApiModel> {
-        return this._http.post(RestPath.erupt + "/change-pwd", {}, {
+        return this._http.get(RestPath.erupt + "/change-pwd", {
                 account: account,
                 pwd: pwd,
                 newPwd: newPwd,

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -366,7 +366,7 @@ export class DataService {
     }
 
     logout() {
-        return this._http.post(RestPath.erupt + "/logout");
+        return this._http.get(RestPath.erupt + "/logout");
     }
 
 

--- a/src/app/shared/util/erupt.util.ts
+++ b/src/app/shared/util/erupt.util.ts
@@ -21,6 +21,8 @@ export function generateMenuPath(type: string, value: string) {
             return "/" + menuValue;
         case MenuTypeEnum.newWindow:
             return "/" + menuValue;
+        case MenuTypeEnum.selfWindow:
+            return "/" + menuValue;
         case MenuTypeEnum.link:
             return "/site/" + encodeURIComponent(window.btoa(encodeURIComponent(menuValue)));
         case MenuTypeEnum.fill:

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -48,7 +48,7 @@
   "tree.base": "基本信息",
   "tree.update": "更新",
   "tree.add_button": "新增",
-  "tree.add": "增加",
+  "tree.add": "保存",
   "tree.add_children": "增加下级",
   "tree.delete": "删除",
   "tree.validate.no_this_parent": "不可以选择自己作为父级",


### PR DESCRIPTION
🐞 修复JDK17任务维护保存报错的bug
🧩 HyperModel、MetaModel 相关类增加表注释
🧩 用户密码被重置后清空密码重置时间字段值，下次登录强制修改密码
🧩 升级magic-api版本至2.0.2
🧩 更清晰的表达各菜单类型含义
🧩 EruptAppProp类转移到UPMS包下
🧩 解决在子类覆盖父类属性时，错误的使用父类EruptField设置 [#23](https://gitee.com/erupt/erupt/pulls/23)
🌟 菜单维护→菜单类型字段新增在当前窗口打开链接功能
🌟 EruptField 字段兼容枚举类型（需配合JPA [@Enumerated](https://blog.csdn.net/GMingZhou/article/details/103595917) 注解使用） [#120](https://github.com/erupts/erupt/pull/120)
🌟 DataProxy支持excelImport方法，可以将导入的WorkBook对象前置处理（接收类型为Object需要类型转换）