### PR TITLE
1.11.1

### DIFF
--- a/src/app/build/erupt/components/checkbox/checkbox.component.less
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.less
@@ -1,0 +1,13 @@
+:host {
+  ::ng-deep {
+    label[nz-checkbox] {
+      max-width: 140px;
+      line-height: initial;
+      margin-left: 0;
+      margin-bottom: 12px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+}

--- a/src/app/build/erupt/components/checkbox/checkbox.component.ts
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.ts
@@ -7,7 +7,7 @@ import {Checkbox} from "../../model/erupt.model";
 @Component({
     selector: 'erupt-checkbox',
     templateUrl: './checkbox.component.html',
-    styles: []
+    styleUrls: ['./checkbox.component.less']
 })
 export class CheckboxComponent implements OnInit {
 

--- a/src/app/build/erupt/components/edit-type/edit-type.component.less
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.less
@@ -2,10 +2,13 @@
   ::ng-deep {
 
     label[nz-checkbox] {
-      min-width: 120px;
+      max-width: 140px;
       line-height: initial;
       margin-left: 0;
       margin-bottom: 12px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     label[nz-radio] {

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -34,6 +34,7 @@ export class TableComponent implements OnInit {
     constructor(
         public settingSrv: SettingsService,
         private dataService: DataService,
+        private dataHandlerService: DataHandlerService,
         private modalHelper: ModalHelper,
         private drawerHelper: DrawerHelper,
         @Inject(NzMessageService)
@@ -412,7 +413,7 @@ export class TableComponent implements OnInit {
                 }
             });
         } else if (ro.type === OperationType.ERUPT) {
-            let operationErupt = null;
+            let operationErupt: EruptModel = null;
             if (this.eruptBuildModel.operationErupts) {
                 operationErupt = this.eruptBuildModel.operationErupts[ro.code];
             }
@@ -453,6 +454,11 @@ export class TableComponent implements OnInit {
                         },
                         parentEruptName: this.eruptBuildModel.eruptModel.eruptName
                     }
+                });
+                this.dataService.getInitValue(operationErupt.eruptName, this.eruptBuildModel.eruptModel.eruptName).subscribe(data => {
+                    this.dataHandlerService.objectToEruptValue(data, {
+                        eruptModel: operationErupt
+                    });
                 });
             } else {
                 this.modal.confirm({

--- a/src/app/layout/default/default.component.ts
+++ b/src/app/layout/default/default.component.ts
@@ -167,7 +167,9 @@ export class LayoutDefaultComponent implements OnInit, AfterViewInit, OnDestroy 
                 name: userinfo.nickname,
                 indexPath: path
             });
-            path && this.router.navigateByUrl(path).then();
+            if (this.router.url === "/") {
+                path && this.router.navigateByUrl(path).then();
+            }
             if (userinfo.resetPwd) {
                 this.modal.create({
                     nzTitle: this.i18n.fanyi("global.reset_pwd"),

--- a/src/app/layout/default/default.component.ts
+++ b/src/app/layout/default/default.component.ts
@@ -12,7 +12,7 @@ import {
 } from "@angular/core";
 import {DOCUMENT} from "@angular/common";
 import {ActivatedRoute, NavigationCancel, NavigationEnd, NavigationError, RouteConfigLoadStart, Router} from "@angular/router";
-import {NzIconService, NzMessageService} from "ng-zorro-antd";
+import {NzIconService, NzMessageService, NzModalService} from "ng-zorro-antd";
 import {Subscription} from "rxjs";
 import {updateHostClass} from "@delon/util";
 import {ALAIN_I18N_TOKEN, Menu, MenuService, ScrollService, SettingsService} from "@delon/theme";
@@ -40,6 +40,7 @@ import {generateMenuPath} from "@shared/util/erupt.util";
 import {MenuTypeEnum} from "@shared/model/erupt-menu";
 import {I18NService} from "@core";
 import {StatusService} from "@shared/service/status.service";
+import {ChangePwdComponent} from "../../routes/change-pwd/change-pwd.component";
 
 // #region icons
 
@@ -97,7 +98,10 @@ export class LayoutDefaultComponent implements OnInit, AfterViewInit, OnDestroy 
                 public settingSrv: SettingsService,
                 public route: ActivatedRoute,
                 public data: DataService,
+                private settingsService: SettingsService,
                 private statusService: StatusService,
+                @Inject(NzModalService)
+                private modal: NzModalService,
                 @Inject(ALAIN_I18N_TOKEN) private i18n: I18NService,
                 @Inject(DA_SERVICE_TOKEN) private tokenService: TokenService,
                 @Inject(DOCUMENT) private doc: any) {
@@ -157,10 +161,27 @@ export class LayoutDefaultComponent implements OnInit, AfterViewInit, OnDestroy 
     ngOnInit() {
         this.notify$ = this.settings.notify.subscribe(() => this.setClass());
         this.setClass();
-        //fill menu
-        if (this.router.url === "/") {
-            this.tokenService.get().indexPath && this.router.navigateByUrl(this.tokenService.get().indexPath).then();
-        }
+        this.data.getUserinfo().subscribe(userinfo => {
+            let path = generateMenuPath(userinfo.indexMenuType, userinfo.indexMenuValue);
+            this.settingsService.setUser({
+                name: userinfo.nickname,
+                indexPath: path
+            });
+            path && this.router.navigateByUrl(path).then();
+            if (userinfo.resetPwd) {
+                this.modal.create({
+                    nzTitle: this.i18n.fanyi("global.reset_pwd"),
+                    nzMaskClosable: false,
+                    nzClosable: true,
+                    nzKeyboard: true,
+                    nzContent: ChangePwdComponent,
+                    nzFooter: null,
+                    nzBodyStyle: {
+                        paddingBottom: '1px'
+                    }
+                });
+            }
+        });
         this.data.getMenu().subscribe(res => {
             // this.statusService.menus = res;
             function generateTree(menus, pid): Menu[] {

--- a/src/app/layout/default/header/components/user.component.ts
+++ b/src/app/layout/default/header/components/user.component.ts
@@ -46,7 +46,6 @@ export class HeaderUserComponent {
                 this.data.logout().subscribe();
                 if (WindowModel.logout) {
                     WindowModel.logout({
-                        account: this.tokenService.get().account,
                         userName: this.settings.user.name,
                         token: this.tokenService.get().token
                     });

--- a/src/app/routes/change-pwd/change-pwd.component.ts
+++ b/src/app/routes/change-pwd/change-pwd.component.ts
@@ -88,7 +88,7 @@ export class ChangePwdComponent {
         }
         if (this.form.invalid) return;
         this.loading = true;
-        this.data.changePwd(this.tokenService.get().account, this.pwd.value, this.newPwd.value, this.newPwd2.value)
+        this.data.changePwd(this.pwd.value, this.newPwd.value, this.newPwd2.value)
             .subscribe(api => {
                 this.loading = false;
                 if (api.status == Status.SUCCESS) {

--- a/src/app/routes/home/home.component.html
+++ b/src/app/routes/home/home.component.html
@@ -1,4 +1,4 @@
-<div class="page-container">
+<div class="page-container" *ngIf="url">
     <nz-spin [nzSpinning]="spin" style="height:100%;width: 100%">
         <iframe *ngIf="url" (load)="iframeLoad()" [src]="url | safeUrl" frameborder="0" height="100%" width="100%" style="vertical-align: bottom;">
         </iframe>

--- a/src/app/routes/home/home.component.ts
+++ b/src/app/routes/home/home.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
-import {NzModalService} from "ng-zorro-antd";
 import {EruptAppData} from "@core/startup/erupt-app.data";
+import {SettingsService} from "@delon/theme";
+import {Router} from "@angular/router";
 
 @Component({
     selector: 'app-home',
@@ -13,11 +14,16 @@ export class HomeComponent implements OnInit {
 
     spin: boolean = true;
 
-    constructor(private modal: NzModalService) {
+    constructor(private settingsService: SettingsService, private router: Router) {
     }
 
     ngOnInit() {
-        this.url = "home.html?v=" + EruptAppData.get().hash;
+        let path = this.settingsService.user.indexPath;
+        if (path) {
+            this.router.navigateByUrl(path).then();
+        } else {
+            this.url = "home.html?v=" + EruptAppData.get().hash;
+        }
     }
 
     iframeLoad() {

--- a/src/app/routes/passport/login/login.component.ts
+++ b/src/app/routes/passport/login/login.component.ts
@@ -121,27 +121,17 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
             pwd = <string>Md5.hashStr(Md5.hashStr(this.password.value) + (new Date().getDate() + "") + this.userName.value);
         }
         this.data.login(this.userName.value, pwd, this.verifyCode.value, this.verifyCodeMark).subscribe((result) => {
-            if (result.useVerifyCode) {
-                this.changeVerifyCode();
-            }
+            if (result.useVerifyCode) this.changeVerifyCode();
             this.useVerifyCode = result.useVerifyCode;
             if (result.pass) {
-                if (result.indexMenu) {
-                    let split = result.indexMenu.split("||");
-                    result.indexPath = generateMenuPath(split[0], split[1]);
-                }
-                this.settingsService.setUser({name: result.userName, indexPath: result.indexPath});
                 this.tokenService.set({
                     token: result.token,
-                    account: this.userName.value,
-                    indexPath: result.indexPath
+                    account: this.userName.value
                 });
                 if (WindowModel.login) {
                     WindowModel.login({
                         token: result.token,
-                        userName: result.userName,
-                        account: this.userName.value,
-                        indexPath: result.indexPath
+                        account: this.userName.value
                     });
                 }
                 this.loading = false;
@@ -152,19 +142,6 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
                         this.router.navigateByUrl(<string>loginBackPath).then();
                     } else {
                         this.router.navigateByUrl("/").then();
-                    }
-                    if (result.resetPwd) {
-                        this.modal.create({
-                            nzTitle: this.i18n.fanyi("global.reset_pwd"),
-                            nzMaskClosable: false,
-                            nzClosable: false,
-                            nzKeyboard: true,
-                            nzContent: ChangePwdComponent,
-                            nzFooter: null,
-                            nzBodyStyle: {
-                                paddingBottom: '1px'
-                            }
-                        });
                     }
                 } else {
                     this.modelFun();

--- a/src/app/routes/passport/login/login.component.ts
+++ b/src/app/routes/passport/login/login.component.ts
@@ -41,6 +41,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
 
     registerPage: string = WindowModel.registerPage;
 
+    verifyCodeMark: number;
+
     constructor(
         fb: FormBuilder,
         private data: DataService,
@@ -118,8 +120,7 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
         if (EruptAppData.get().pwdTransferEncrypt) {
             pwd = <string>Md5.hashStr(Md5.hashStr(this.password.value) + (new Date().getDate() + "") + this.userName.value);
         }
-        this.data.login(this.userName.value, pwd,
-            this.verifyCode.value).subscribe((result) => {
+        this.data.login(this.userName.value, pwd, this.verifyCode.value, this.verifyCodeMark).subscribe((result) => {
             if (result.useVerifyCode) {
                 this.changeVerifyCode();
             }
@@ -183,7 +184,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
     }
 
     changeVerifyCode() {
-        this.verifyCodeUrl = DataService.getVerifyCodeUrl();
+        this.verifyCodeMark = Math.ceil(Math.random() * new Date().getTime());
+        this.verifyCodeUrl = DataService.getVerifyCodeUrl(this.verifyCodeMark);
     }
 
     forgot() {

--- a/src/app/shared/model/user.model.ts
+++ b/src/app/shared/model/user.model.ts
@@ -4,8 +4,11 @@ export interface LoginModel {
     useVerifyCode: boolean;
     pass: boolean;
     reason: string;
-    userName: string;
+}
+
+export interface Userinfo {
+    nickname: string;
+    indexMenuType: string;
+    indexMenuValue: string;
     resetPwd: boolean;
-    indexPath?: string;
-    indexMenu?: string;
 }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -3,7 +3,7 @@ import {HttpClient} from "@angular/common/http";
 import {Checkbox, Page, Row, Tree} from "../../build/erupt/model/erupt.model";
 import {_HttpClient, ALAIN_I18N_TOKEN} from "@delon/theme";
 import {Observable} from "rxjs";
-import {LoginModel} from "../model/user.model";
+import {LoginModel, Userinfo} from "../model/user.model";
 import {EruptApiModel} from "../../build/erupt/model/erupt-api.model";
 import {EruptBuildModel} from "../../build/erupt/model/erupt-build.model";
 import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
@@ -394,7 +394,11 @@ export class DataService {
 
     //获取菜单
     getMenu(): Observable<MenuVo[]> {
-        return this._http.get<MenuVo[]>(RestPath.erupt + "/menu", null);
+        return this._http.get<MenuVo[]>(RestPath.erupt + "/menu");
+    }
+
+    getUserinfo(): Observable<Userinfo> {
+        return this._http.get<Userinfo>(RestPath.erupt + "/userinfo");
     }
 
     downloadExcelTemplate(eruptName: string, callback?) {

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -382,9 +382,8 @@ export class DataService {
     }
 
 
-    changePwd(account: string, pwd: string, newPwd: string, newPwd2: string): Observable<EruptApiModel> {
+    changePwd(pwd: string, newPwd: string, newPwd2: string): Observable<EruptApiModel> {
         return this._http.get(RestPath.erupt + "/change-pwd", {
-                account: account,
                 pwd: pwd,
                 newPwd: newPwd,
                 newPwd2: newPwd2

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -50,8 +50,8 @@ export class DataService {
     }
 
     //获取验证码
-    static getVerifyCodeUrl(): string {
-        return RestPath.erupt + "/code-img?_t" + new Date().getTime();
+    static getVerifyCodeUrl(mark: any): string {
+        return RestPath.erupt + "/code-img?mark=" + mark;
     }
 
     static downloadAttachment(path: string): string {
@@ -367,11 +367,12 @@ export class DataService {
     }
 
     //登录
-    login(account: string, pwd: string, verifyCode?: any): Observable<LoginModel> {
+    login(account: string, pwd: string, verifyCode?: any, verifyCodeMark?: any): Observable<LoginModel> {
         return this._http.get(RestPath.erupt + "/login", {
                 account: account,
                 pwd: pwd,
-                verifyCode: verifyCode
+                verifyCode: verifyCode,
+                verifyCodeMark: verifyCodeMark
             }
         );
     }

--- a/src/auth.html
+++ b/src/auth.html
@@ -7,14 +7,8 @@
 <body>
 <script>
     var auth = JSON.parse(window.decodeURIComponent(window.atob(location.search.substring(1))));
-    localStorage.setItem("user", JSON.stringify({
-        name: auth.userName,
-        indexPath: auth.indexPath
-    }));
     localStorage.setItem("_token", JSON.stringify({
-        token: auth.token,
-        account: auth.userName,
-        indexPath: auth.indexPath
+        token: auth.token
     }));
     window.location = "./index.html";
 </script>

--- a/src/auth.html
+++ b/src/auth.html
@@ -8,7 +8,7 @@
 <script>
     let param = {};
     let paramsArr = location.search.substring(1).split('&')
-    for(let i = 0,len = paramsArr.length;i < len;i++){
+    for (let i = 0, len = paramsArr.length; i < len; i++) {
         let arr = paramsArr[i].split('=')
         param[arr[0]] = arr[1];
     }

--- a/src/auth.html
+++ b/src/auth.html
@@ -6,9 +6,8 @@
 </head>
 <body>
 <script>
-    var auth = JSON.parse(window.decodeURIComponent(window.atob(location.search.substring(1))));
     localStorage.setItem("_token", JSON.stringify({
-        token: auth.token
+        token: location.search.substring(1)
     }));
     window.location = "./index.html";
 </script>

--- a/src/auth.html
+++ b/src/auth.html
@@ -12,7 +12,6 @@
         let arr = paramsArr[i].split('=')
         param[arr[0]] = arr[1];
     }
-    document.writeln(JSON.stringify(param))
     localStorage.setItem("_token", param["token"]);
     window.location = "./index.html";
 </script>

--- a/src/auth.html
+++ b/src/auth.html
@@ -6,9 +6,14 @@
 </head>
 <body>
 <script>
-    localStorage.setItem("_token", JSON.stringify({
-        token: location.search.substring(1)
-    }));
+    let param = {};
+    let paramsArr = location.search.substring(1).split('&')
+    for(let i = 0,len = paramsArr.length;i < len;i++){
+        let arr = paramsArr[i].split('=')
+        param[arr[0]] = arr[1];
+    }
+    document.writeln(JSON.stringify(param))
+    localStorage.setItem("_token", param["token"]);
     window.location = "./index.html";
 </script>
 </body>


### PR DESCRIPTION
🐞 修复创建新用户时超管标记无效的 BUG
🐞 修复保存时未触发动态readonly的 BUG
🐞 修复菜单管理按钮禁用状态不生效的 BUG
🐞 修复内网情况下同IP获取验证码校验失效的 BUG
🧩 简化自定义登录页授权参数
🧩 重置用户密码使用独立的按钮
🧩 修改密码接口、登录接口强制使用GET请求
🧩 修改密码接口移除account参数，通过token获取
🧩 登录用户基础信息每次都会从接口获取而不是登录后一直缓存
🧩 用户管理 → 首页菜单弹出时不会展示功能按钮类数据，方便选择有效视图菜单
🌟 弹出层表单支持默认值渲染
🌟 @view 注解提供 ifRender 配置，支持动态表格列渲染
🌟 @edit 注解提供 ifRender 配置，支持动态表单渲染