### PR TITLE
1.12.10

### DIFF
--- a/src/app/build/bi/chart-table/chart-table.component.html
+++ b/src/app/build/bi/chart-table/chart-table.component.html
@@ -1,6 +1,8 @@
-<!--<div #s2t style="width: 100%;height: 100%">-->
+<div *ngIf="!data||data.length==0" class="flex-center-center">
+    <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null">
 
-<!--</div>-->
+    </nz-empty>
+</div>
 <table *ngIf="data&&data.length>0">
     <tr>
         <th *ngFor="let data of data[0] | keyvalue">{{data.key}}</th>

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -14,11 +14,11 @@
                 </ng-container>
                 <ng-container *ngSwitchCase="chartType.table">
                     <div [ngStyle]="{height:chart.height+'px'}" style="overflow: auto">
-                        <erupt-chart-table #chartTable></erupt-chart-table>
+                        <erupt-chart-table #chartTable [id]="chart.code"></erupt-chart-table>
                     </div>
                 </ng-container>
                 <ng-container *ngSwitchCase="chartType.Number">
-                    <div style="padding: 12px;text-align: center;">
+                    <div style="padding: 12px;text-align: center;" [id]="chart.code">
                         <div sg-container="{{data.length}}">
                             <ng-container *ngFor="let d of data">
                                 <sg>

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -8,32 +8,49 @@
                     <i nz-icon nzType="pie-chart" nzTheme="twotone" style="font-size: 36px"></i>
                 </div>
             </ng-container>
-            <ng-container *ngIf="ready" [ngSwitch]="chart.type">
-                <ng-container *ngSwitchCase="chartType.tpl">
-                    <erupt-iframe [url]="src" [style]="{height:chart.height+'px',paddingTop:'1px'}"></erupt-iframe>
-                </ng-container>
-                <ng-container *ngSwitchCase="chartType.table">
-                    <div [ngStyle]="{height:chart.height+'px'}" style="overflow: auto">
-                        <erupt-chart-table #chartTable [id]="chart.code"></erupt-chart-table>
-                    </div>
-                </ng-container>
-                <ng-container *ngSwitchCase="chartType.Number">
-                    <div style="padding: 12px;text-align: center;" [id]="chart.code">
-                        <div sg-container="{{data.length}}">
-                            <ng-container *ngFor="let d of data">
-                                <sg>
-                                    <nz-statistic style="margin-bottom: 16px;"
-                                                  [nzValue]="d[dataKeys[0]]||0"
-                                                  [nzTitle]="d[dataKeys[1]]"
-                                                  [nzValueStyle]="this.chart.chartOption"
-                                    ></nz-statistic>
-                                </sg>
+            <ng-container *ngIf="ready">
+                <ng-container [ngSwitch]="chart.type">
+                    <ng-container *ngSwitchCase="chartType.tpl">
+                        <erupt-iframe [url]="src" [style]="{height:chart.height+'px',paddingTop:'1px'}">
+
+                        </erupt-iframe>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="chartType.table">
+                        <div [ngStyle]="{height:chart.height+'px'}" style="overflow: auto">
+                            <erupt-chart-table #chartTable [id]="chart.code"></erupt-chart-table>
+                        </div>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="chartType.Number">
+                        <ng-container *ngIf="!data||data.length==0">
+                            <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center">
+
+                            </nz-empty>
+                        </ng-container>
+                        <ng-container *ngIf="data&&data.length">
+                            <div style="padding: 12px;text-align: center;" [id]="chart.code">
+                                <div sg-container="{{data.length}}">
+                                    <ng-container *ngFor="let d of data">
+                                        <sg>
+                                            <nz-statistic style="margin-bottom: 16px;"
+                                                          [nzValue]="d[dataKeys[0]]||0"
+                                                          [nzTitle]="d[dataKeys[1]]"
+                                                          [nzValueStyle]="this.chart.chartOption"
+                                            ></nz-statistic>
+                                        </sg>
+                                    </ng-container>
+                                </div>
+                            </div>
+                        </ng-container>
+                    </ng-container>
+                    <ng-container *ngSwitchDefault>
+                        <div [id]='chart.code' style='width:100%;' [ngStyle]="{height:chart.height+'px'}">
+                            <ng-container *ngIf="!data||data.length==0">
+                                <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center">
+
+                                </nz-empty>
                             </ng-container>
                         </div>
-                    </div>
-                </ng-container>
-                <ng-container *ngSwitchDefault>
-                    <div [id]='chart.code' style='width:100%;' [ngStyle]="{height:chart.height+'px'}"></div>
+                    </ng-container>
                 </ng-container>
             </ng-container>
         </div>

--- a/src/app/build/bi/chart/chart.component.ts
+++ b/src/app/build/bi/chart/chart.component.ts
@@ -301,6 +301,7 @@ export class ChartComponent implements OnInit, OnDestroy {
                     this.chart.code,
                     Object.assign(props, {
                         seriesField: x,
+                        // isStack: !!series,
                         radius: 0.9,
                         label: {
                             offset: -15

--- a/src/app/build/bi/chart/chart.component.ts
+++ b/src/app/build/bi/chart/chart.component.ts
@@ -409,6 +409,7 @@ export class ChartComponent implements OnInit, OnDestroy {
                         wordField: x,
                         weightField: y,
                         colorField: series,
+                        interactions: [{ type: 'element-active' }],
                         wordStyle: {}
                     }) as WordCloudOptions
                 );

--- a/src/app/build/bi/chart/chart.component.ts
+++ b/src/app/build/bi/chart/chart.component.ts
@@ -300,8 +300,7 @@ export class ChartComponent implements OnInit, OnDestroy {
                 this.plot = new Rose(
                     this.chart.code,
                     Object.assign(props, {
-                        seriesField: series,
-                        isGroup: !!series,
+                        seriesField: x,
                         radius: 0.9,
                         label: {
                             offset: -15

--- a/src/app/build/bi/skeleton/skeleton.component.html
+++ b/src/app/build/bi/skeleton/skeleton.component.html
@@ -88,7 +88,7 @@
                 <ng-container *ngIf="bi.table">
                     <ng-container *ngIf="columns.length <= 0">
                         <nz-card>
-                            <nz-empty></nz-empty>
+                            <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null"></nz-empty>
                         </nz-card>
                     </ng-container>
                     <ng-container *ngIf="columns && columns.length > 0">

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -176,7 +176,7 @@ export class UiBuildService {
                     };
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-link' aria-hidden='true'></i>";
+                            return "<i class='fa fa-link' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -187,7 +187,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-dot-circle-o' aria-hidden='true'></i>";
+                            return "<i class='fa fa-dot-circle-o' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -214,7 +214,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-qrcode' aria-hidden='true'></i>";
+                            return "<i class='fa fa-qrcode' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -239,7 +239,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-file-text' aria-hidden='true'></i>";
+                            return "<i class='fa fa-file-text' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -266,7 +266,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-code' aria-hidden='true'></i>";
+                            return "<i class='fa fa-code' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -299,7 +299,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-map' aria-hidden='true'></i>";
+                            return "<i class='fa fa-map' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -360,7 +360,7 @@ export class UiBuildService {
                     obj.className = "text-center";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<i class='fa fa-file-text' aria-hidden='true'></i>`;
+                            return `<i class='fa fa-file-text' aria-hidden='true' title=''></i>`;
                         } else {
                             return "";
                         }
@@ -386,7 +386,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return "<i class='fa fa-file-text' aria-hidden='true'></i>";
+                            return "<i class='fa fa-file-text' aria-hidden='true' title=''></i>";
                         } else {
                             return "";
                         }
@@ -412,7 +412,7 @@ export class UiBuildService {
                     obj.className = "text-center";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<i class='fa fa-file-image-o' aria-hidden='true'></i>`;
+                            return `<i class='fa fa-file-image-o' aria-hidden='true' title=''></i>`;
                         } else {
                             return "";
                         }
@@ -439,7 +439,7 @@ export class UiBuildService {
                     obj.className = "text-center p-sm";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<img width="100%" src="${item[view.column]}" />`;
+                            return `<img width="100%" src="${item[view.column]}" title=""/>`;
                         } else {
                             return "";
                         }
@@ -465,7 +465,7 @@ export class UiBuildService {
                     obj.className = "text-center";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<i class='fa fa-dot-circle-o' aria-hidden='true'></i>`;
+                            return `<i class='fa fa-dot-circle-o' aria-hidden='true' title=""></i>`;
                         } else {
                             return "";
                         }
@@ -489,7 +489,7 @@ export class UiBuildService {
                     obj.className = "text-center";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<i class='fa fa-download' aria-hidden='true'></i>`;
+                            return `<i class='fa fa-download' aria-hidden='true' title=""></i>`;
                         } else {
                             return "";
                         }
@@ -503,7 +503,7 @@ export class UiBuildService {
                     obj.className = "text-center";
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            return `<i class='fa fa-window-restore' aria-hidden='true'></i>`;
+                            return `<i class='fa fa-window-restore' aria-hidden='true' title=""></i>`;
                         } else {
                             return "";
                         }
@@ -516,7 +516,7 @@ export class UiBuildService {
                     obj.type = "link";
                     obj.className = "text-center";
                     obj.format = (item: any) => {
-                        return `<i class='fa fa-adjust' aria-hidden='true'></i>`;
+                        return `<i class='fa fa-adjust' aria-hidden='true' title=""></i>`;
                     };
                     obj.click = (item) => {
                         let ref = this.modal.create({

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -340,7 +340,7 @@ export class UiBuildService {
                             for (let i in imgs) {
                                 imgElements[i] = `<img width="100%" class="e-table-img" src="${DataService.previewAttachment(imgs[i])}" alt=""/>`;
                             }
-                            return `<div style="text-align: center;display:flex;justify-content: center;">
+                            return `<div style="text-align: center;display:flex;justify-content: center;" title="${view.title}">
                                         ${imgElements.join(" ")}
                                     </div>`;
                         } else {

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -586,7 +586,7 @@ export class TableComponent implements OnInit {
                 nzFooter: null,
                 nzContent: EruptIframeComponent,
                 nzOnCancel: () => {
-                    this.query();
+                    // this.query();
                 }
             });
             ref.getContentComponent().url = url;

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -32,6 +32,7 @@ import {deepCopy} from "@delon/util";
 import {ModalButtonOptions} from "ng-zorro-antd/modal/modal-types";
 import {STChange, STPage} from "@delon/abc/st/st.interfaces";
 import {AppViewService} from "@shared/service/app-view.service";
+import {EruptStorageService} from "@shared/service/erupt-storage.service";
 
 
 @Component({
@@ -53,6 +54,7 @@ export class TableComponent implements OnInit {
         private appViewService: AppViewService,
         private dataHandler: DataHandlerService,
         private uiBuildService: UiBuildService,
+        private eruptStorageService: EruptStorageService,
         private i18n: I18NService,
     ) {
     }
@@ -629,7 +631,7 @@ export class TableComponent implements OnInit {
                 modal.getContentComponent().mode = Scene.ADD;
                 modal.getContentComponent().eruptBuildModel = {eruptModel: operationErupt};
                 modal.getContentComponent().parentEruptName = this.eruptBuildModel.eruptModel.eruptName;
-                this.dataService.getInitValue(operationErupt.eruptName, this.eruptBuildModel.eruptModel.eruptName,this._drill ? DataService.drillToHeader(this._drill) : {}).subscribe(data => {
+                this.dataService.getInitValue(operationErupt.eruptName, this.eruptBuildModel.eruptModel.eruptName, this._drill ? DataService.drillToHeader(this._drill) : {}).subscribe(data => {
                     this.dataHandlerService.objectToEruptValue(data, {
                         eruptModel: operationErupt
                     });

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -584,7 +584,10 @@ export class TableComponent implements OnInit {
                     padding: "0"
                 },
                 nzFooter: null,
-                nzContent: EruptIframeComponent
+                nzContent: EruptIframeComponent,
+                nzOnCancel: () => {
+                    this.query();
+                }
             });
             ref.getContentComponent().url = url;
         } else if (ro.type === OperationType.ERUPT) {
@@ -610,7 +613,7 @@ export class TableComponent implements OnInit {
                         modal.componentInstance.nzCancelDisabled = false;
                         this.selectedRows = [];
                         if (res.status === Status.SUCCESS) {
-                            this.query(1);
+                            this.query();
                             if (res.data) {
                                 try {
                                     let msg = this.msg;
@@ -643,7 +646,7 @@ export class TableComponent implements OnInit {
                         this.selectedRows = [];
                         let res = await this.dataService.execOperatorFun(this.eruptBuildModel.eruptModel.eruptName, ro.code, ids, null)
                             .toPromise().then();
-                        this.query(1);
+                        this.query();
                         if (res.data) {
                             try {
                                 let msg = this.msg;

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -32,7 +32,6 @@ import {deepCopy} from "@delon/util";
 import {ModalButtonOptions} from "ng-zorro-antd/modal/modal-types";
 import {STChange, STPage} from "@delon/abc/st/st.interfaces";
 import {AppViewService} from "@shared/service/app-view.service";
-import {EruptStorageService} from "@shared/service/erupt-storage.service";
 
 
 @Component({
@@ -54,8 +53,7 @@ export class TableComponent implements OnInit {
         private appViewService: AppViewService,
         private dataHandler: DataHandlerService,
         private uiBuildService: UiBuildService,
-        private eruptStorageService: EruptStorageService,
-        private i18n: I18NService,
+        private i18n: I18NService
     ) {
     }
 

--- a/src/app/build/erupt/view/tree/tree.component.html
+++ b/src/app/build/erupt/view/tree/tree.component.html
@@ -57,7 +57,7 @@
                     <nz-collapse nzAccordion nzExpandIconPosition="right">
                         <nz-collapse-panel [nzActive]="true" [nzHeader]="'tree.base'|translate" [nzDisabled]="true" [nzShowArrow]="false">
                             <nz-spin [nzSpinning]="loading" nzSize="large">
-                                <erupt-edit [eruptBuildModel]="eruptBuildModel">
+                                <erupt-edit [eruptBuildModel]="eruptBuildModel" [behavior]="behavior">
 
                                 </erupt-edit>
                             </nz-spin>

--- a/src/app/build/erupt/view/tree/tree.component.ts
+++ b/src/app/build/erupt/view/tree/tree.component.ts
@@ -12,6 +12,7 @@ import {NzFormatEmitEvent, NzTreeBaseService} from "ng-zorro-antd/core/tree";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {AppViewService} from "@shared/service/app-view.service";
+import {Scene} from "../../model/erupt.enum";
 
 @Component({
     selector: "erupt-tree",
@@ -32,7 +33,9 @@ export class TreeComponent implements OnInit, OnDestroy {
 
     treeLoading = false;
 
-    searchValue;
+    behavior: Scene = Scene.ADD;
+
+    searchValue: string;
 
     nodes: any = [];
 
@@ -84,6 +87,7 @@ export class TreeComponent implements OnInit, OnDestroy {
         if (this.tree.getSelectedNodeList()[0]) {
             this.tree.getSelectedNodeList()[0].isSelected = false;
         }
+        this.behavior = Scene.ADD;
         this.dataService.getInitValue(this.eruptBuildModel.eruptModel.eruptName).subscribe(data => {
             this.loading = false;
             this.dataHandler.objectToEruptValue(data, this.eruptBuildModel);
@@ -92,6 +96,7 @@ export class TreeComponent implements OnInit, OnDestroy {
     }
 
     addSub() {
+        this.behavior = Scene.ADD;
         let eruptFieldModelMap = this.eruptBuildModel.eruptModel.eruptFieldModelMap;
         let id = eruptFieldModelMap.get(this.eruptBuildModel.eruptModel.eruptJson.tree.id).eruptFieldJson.edit.$value;
         let label = eruptFieldModelMap.get(this.eruptBuildModel.eruptModel.eruptJson.tree.label).eruptFieldJson.edit.$value;
@@ -106,6 +111,7 @@ export class TreeComponent implements OnInit, OnDestroy {
 
     add() {
         this.loading = true;
+        this.behavior = Scene.ADD;
         this.dataService.addEruptData(this.eruptBuildModel.eruptModel.eruptName,
             this.dataHandler.eruptValueToObject(this.eruptBuildModel)).subscribe(result => {
             this.loading = false;
@@ -169,6 +175,7 @@ export class TreeComponent implements OnInit, OnDestroy {
                 nzTitle: this.i18n.fanyi("global.delete.hint"),
                 nzContent: "",
                 nzOnOk: () => {
+                    this.behavior = Scene.ADD;
                     this.dataService.deleteEruptData(this.eruptBuildModel.eruptModel.eruptName, nzTreeNode.origin.key)
                         .subscribe(res => {
                             if (res.status == Status.SUCCESS) {
@@ -224,6 +231,7 @@ export class TreeComponent implements OnInit, OnDestroy {
         this.loading = true;
         this.showEdit = true;
         this.currentKey = event.node.origin.key;
+        this.behavior = Scene.EDIT;
         this.dataService.queryEruptDataById(this.eruptBuildModel.eruptModel.eruptName, this.currentKey).subscribe(data => {
             this.dataHandler.objectToEruptValue(data, this.eruptBuildModel);
             this.loading = false;

--- a/src/app/layout/erupt/header/components/search.component.ts
+++ b/src/app/layout/erupt/header/components/search.component.ts
@@ -1,8 +1,6 @@
 import {AfterViewInit, Component, ElementRef, HostBinding, Inject, Input} from '@angular/core';
-import {DataService} from "@shared/service/data.service";
 import {Router} from "@angular/router";
 import {MenuTypeEnum, MenuVo} from "@shared/model/erupt-menu";
-import {StatusService} from "@shared/service/status.service";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {generateMenuPath} from "@shared/util/erupt.util";
 
@@ -11,7 +9,7 @@ import {generateMenuPath} from "@shared/util/erupt.util";
     template: `
         <ng-container *ngIf="menu">
             <nz-input-group [nzSuffix]="suffixTemplateInfo" [nzPrefix]="prefixTemplateInfo">
-                <input nz-input [(ngModel)]="text" (focus)="qFocus()" (blur)="qBlur()" (input)="onInput($event)"
+                <input nz-input autofocus [(ngModel)]="text" (focus)="qFocus()" (blur)="qBlur()" (input)="onInput($event)"
                        [placeholder]="'global.search.hint'|translate" [nzAutocomplete]="auto"
                        (keydown.enter)="search($event)">
                 <nz-autocomplete #auto [nzBackfill]="false">

--- a/src/app/shared/component/i18n.component.ts
+++ b/src/app/shared/component/i18n.component.ts
@@ -1,5 +1,5 @@
 import {DOCUMENT} from '@angular/common';
-import {ChangeDetectionStrategy, Component, Inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {I18NService} from '@core';
 import {SettingsService} from '@delon/theme';
 import {EruptAppData} from "@shared/model/erupt-app.model";
@@ -46,6 +46,7 @@ export class HeaderI18nComponent {
                 this.langs.push(lang);
             }
         }
+        this.curLangCode = this.settings.getLayout()['lang']
     }
 
     change(lang: string): void {

--- a/src/app/shared/service/erupt-storage.service.ts
+++ b/src/app/shared/service/erupt-storage.service.ts
@@ -1,0 +1,55 @@
+/**
+ * Created by liyuepeng on 10/16/19.
+ */
+import {Injectable} from "@angular/core";
+
+
+const searchKey = "search";
+
+const columnKey = "column";
+
+@Injectable()
+export class EruptStorageService {
+
+    constructor() {
+    }
+
+    saveSearch(code: string, query: any) {
+        this.save(code, searchKey, query);
+    }
+
+    saveColumnWidth(code: string, column: string, width: number) {
+        // this.save(code, columnKey, data);
+    }
+
+    private save(code: string, key: string, query: any) {
+        let dataStr = localStorage.getItem(code);
+        let data = {};
+        if (!dataStr) {
+            data = JSON.parse(dataStr);
+        }
+        data[key] = query;
+        localStorage.setItem(code, JSON.stringify(data));
+    }
+
+    private delete(code: string, key: string) {
+        let dataStr = localStorage.getItem(code);
+        if (dataStr) {
+            let data = JSON.parse(dataStr);
+            delete data[key];
+        }
+    }
+
+
+}
+
+
+export interface eruptStorage {
+
+    search: any;
+
+    table: Record<string, {
+        width: number;
+    }>
+
+}

--- a/src/app/shared/service/erupt-storage.service.ts
+++ b/src/app/shared/service/erupt-storage.service.ts
@@ -18,18 +18,45 @@ export class EruptStorageService {
         this.save(code, searchKey, query);
     }
 
-    saveColumnWidth(code: string, column: string, width: number) {
-        // this.save(code, columnKey, data);
+    getSearch(code: string): {
+        key: string,
+        value: any
+    }[] {
+        return this.get(code, searchKey);
     }
+
+    clearSearch(code: string) {
+        this.delete(code, searchKey);
+    }
+
+    // saveColumnWidth(code: string, column: string, width: number) {
+    //     let dataStr = localStorage.getItem(code);
+    //     let data = {};
+    //     if (!dataStr) {
+    //         data = JSON.parse(dataStr);
+    //     }
+    //     data["column"] = query;
+    //     localStorage.setItem(code, JSON.stringify(data));
+    // }
 
     private save(code: string, key: string, query: any) {
         let dataStr = localStorage.getItem(code);
         let data = {};
-        if (!dataStr) {
+        if (dataStr) {
             data = JSON.parse(dataStr);
         }
         data[key] = query;
+        console.log(code)
         localStorage.setItem(code, JSON.stringify(data));
+    }
+
+    private get(code: string, key: string): any {
+        let dataStr = localStorage.getItem(code);
+        if (dataStr) {
+            let data = JSON.parse(dataStr);
+            return data[key];
+        }
+        return null;
     }
 
     private delete(code: string, key: string) {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -17,7 +17,7 @@ import {I18nPipe} from "@shared/pipe/i18n.pipe";
 import {NavComponent} from "@shared/nav/nav.component";
 import {NzAffixModule} from "ng-zorro-antd/affix";
 import {HeaderI18nComponent} from "@shared/component/i18n.component";
-import {NzIconModule} from "ng-zorro-antd/icon";
+import {EruptStorageService} from "@shared/service/erupt-storage.service";
 
 // #region third libs
 // import { NgxTinymceModule } from 'ngx-tinymce';
@@ -51,7 +51,8 @@ const DIRECTIVES: Array<Type<any>> = [RipperDirective, SafeHtmlPipe, SafeScriptP
         ...DIRECTIVES,
     ],
     providers: [
-        DataService
+        DataService,
+        EruptStorageService
     ],
     exports: [
         CommonModule,

--- a/src/styles/erupt.less
+++ b/src/styles/erupt.less
@@ -53,3 +53,10 @@ span.ripple {
 .p-mini {
     padding: 6px !important;
 }
+
+.flex-center-center {
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/styles/erupt.less
+++ b/src/styles/erupt.less
@@ -24,8 +24,10 @@ span.ripple {
 }
 
 .e-table-img {
-    max-width: 46px;
-    max-height: 112px;
+    min-width: 36px;
+    max-width: 88px;
+    //max-height: 112px;
+    margin: 0 2px;
     vertical-align: middle;
     border-radius: 4px;
 }


### PR DESCRIPTION
🐞 修复执行自定义按钮会回到第一页的 bug
🐞 修复已选语言不回显的显示 bug
🐞 修复树视图不支持分场景只读的 bug
🐞 解决 erupt-cloud 在 oracle 场景下 e_cloud_node 表无法自动创建的 bug
🐞 解决 oracle 数据库无法创建 upms_menu 表的问题，h2数据库默认读取提交的erupt.mv.db文件
🧩 优化触碰表格图标2秒后会出现标签的显示问题
🧩 优化 erupt-cloud 心跳检测 node 节点查找性能，避免使用 keys *
🧩 eruptDao 新增 findById 方法，防止线程内多次读取对象导致脏读的问题
🧩 支持删除菜单后自动移除关联角色能力
🧩 导出模板支持修饰字段类型是LocalDate 或 LocalDateTime时自动限制填充时间格式的能力
🧩 左树右表、下钻组件组件依据实际类型调整表达式是否需要引号（兼容 jpa6）
🧩 优化 SQL异常提示，错误信息不会统一返回数据重复这种迷惑性文本
🌟 代码生成器增加评分组件生成支持
🌟 input 组件增加 autoTrim 配置，提交内容会自动 trim 默认开启
🌟 erupt-job 增加是否记录日志配置
🌟 erupt-bi 定义图表数据为空时的占位展示 UI
🌟 erupt-bi 图表渲染自动写入ID方便自定义样式或者动态 JS 处理
🌟 erupt-bi 优化词云图交互样式