### PR TITLE
1.12.13

### DIFF
--- a/src/app/build/erupt/components/checkbox/checkbox.component.html
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.html
@@ -3,8 +3,8 @@
         <div nz-row>
             <div nz-col [nzXs]="12" [nzSm]="8" [nzMd]="8" [nzLg]="4" *ngFor="let c of checkbox">
                 <label nz-checkbox [nzDisabled]="onlyRead" [nzValue]="c.id"
-                       nz-tooltip [nzTooltipTitle]="c.remark"
-                       [nzChecked]="edit.$value&&edit.$value.indexOf(c.id)!=-1">{{c.label}}</label>
+                       nz-tooltip [nzTooltipTitle]="c.remark" [title]="c.label"
+                       [nzChecked]="edit.$value&&edit.$value.indexOf(c.id)!=-1">{{ c.label }}</label>
             </div>
         </div>
     </nz-checkbox-wrapper>

--- a/src/app/build/erupt/components/choice/choice.component.html
+++ b/src/app/build/erupt/components/choice/choice.component.html
@@ -5,12 +5,12 @@
                             [name]="eruptField.fieldName"
                             class="erupt-input stander-line-height">
                 <ng-container *ngIf="checkAll">
-                    <label nz-radio [nzValue]="">{{'global.all'|translate}}</label>
+                    <label nz-radio [nzValue]="">{{ 'global.all'|translate }}</label>
                 </ng-container>
                 <ng-container *ngFor="let vl of choiceVL">
                     <label nz-radio nz-tooltip [nzTooltipTitle]="vl.desc"
                            [nzDisabled]="readonly||vl.disable"
-                           [nzValue]="vl.value">{{vl.label}}</label>
+                           [nzValue]="vl.value">{{ vl.label }}</label>
                 </ng-container>
             </nz-radio-group>
         </ng-container>
@@ -24,7 +24,7 @@
                 <ng-container *ngIf="!isLoading">
                     <nz-option *ngFor="let vl of choiceVL" nzCustomContent
                                [nzDisabled]="vl.disable" [nzValue]="vl.value" [nzLabel]="vl.label">
-                        <div nz-tooltip [nzTooltipPlacement]="'left'" [nzTooltipTitle]="vl.desc">{{vl.label}}</div>
+                        <div nz-tooltip [nzTooltipPlacement]="'left'" [nzTooltipTitle]="vl.desc">{{ vl.label }}</div>
                     </nz-option>
                 </ng-container>
                 <nz-option *ngIf="isLoading" nzDisabled nzCustomContent>
@@ -40,10 +40,10 @@
     <tag-select [expandable]="true" style="margin-left: 0;">
         <nz-spin nzSimple *ngIf="isLoading"></nz-spin>
         <nz-tag (nzCheckedChange)="changeTagAll($event)" style="margin-right: 10px"
-                nzMode="checkable">{{'global.check_all'|translate}}
+                nzMode="checkable">{{ 'global.check_all'|translate }}
         </nz-tag>
         <ng-container *ngFor="let vl of choiceVL">
-            <nz-tag style="margin-right: 10px" nzMode="checkable" [(nzChecked)]="vl.$viewValue">{{vl.label}}</nz-tag>
+            <nz-tag style="margin-right: 10px" nzMode="checkable" [(nzChecked)]="vl.$viewValue">{{ vl.label }}</nz-tag>
         </ng-container>
     </tag-select>
 </ng-container>

--- a/src/app/build/erupt/components/choice/choice.component.less
+++ b/src/app/build/erupt/components/choice/choice.component.less
@@ -5,5 +5,8 @@
                 line-height: 32px;
             }
         }
+        //.tag-select__has-expand {
+        //    max-height: 38px;
+        //}
     }
 }

--- a/src/app/build/erupt/components/search-se/search-se.component.html
+++ b/src/app/build/erupt/components/search-se/search-se.component.html
@@ -6,7 +6,7 @@
             &nbsp;
         </label>
     </div>
-    <div style="flex: 1 0 0;width: 100%;overflow: auto">
+    <div style="flex: 1 0 0;width: 100%;">
         <ng-content></ng-content>
     </div>
 </div>

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -50,6 +50,7 @@ interface Layout {
     tableRightFixed: number;
     pageSize: number;
     pageSizes: number[];
+    refreshTime: number;
 }
 
 

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, Input, OnInit, ViewChild} from "@angular/core";
+import {Component, Inject, Input, OnDestroy, OnInit, ViewChild} from "@angular/core";
 import {DataService} from "@shared/service/data.service";
 import {Drill, DrillInput, EruptModel, Row, RowOperation} from "../../model/erupt.model";
 
@@ -40,7 +40,7 @@ import {CodeEditorComponent} from "../../components/code-editor/code-editor.comp
     templateUrl: "./table.component.html",
     styleUrls: ["./table.component.less"]
 })
-export class TableComponent implements OnInit {
+export class TableComponent implements OnInit, OnDestroy {
 
 
     constructor(
@@ -129,6 +129,8 @@ export class TableComponent implements OnInit {
 
     header: object;
 
+    refreshTimeInterval: any;
+
     @Input() set drill(drill: DrillInput) {
         this._drill = drill;
         this.init(this.dataService.getEruptBuild(drill.erupt), {
@@ -188,6 +190,10 @@ export class TableComponent implements OnInit {
 
     }
 
+    ngOnDestroy(): void {
+        this.refreshTimeInterval && clearInterval(this.refreshTimeInterval);
+    }
+
     init(observable: Observable<EruptBuildModel>, req: {
         url: string,
         header: any
@@ -230,6 +236,11 @@ export class TableComponent implements OnInit {
                             this.dataPage.showPagination = false;
                             this.dataPage.page.show = false;
                         }
+                    }
+                    if (layout.refreshTime && layout.refreshTime > 0) {
+                        this.refreshTimeInterval = setInterval(() => {
+                            this.query(1);
+                        }, layout.refreshTime);
                     }
                 }
                 let dt = eb.eruptModel.eruptJson.linkTree;

--- a/src/app/core/net/default.interceptor.ts
+++ b/src/app/core/net/default.interceptor.ts
@@ -178,6 +178,9 @@ export class DefaultInterceptor implements HttpInterceptor {
                 }
                 break;
             case 404:
+                if (event.url.indexOf("/form-value") != -1) {
+                    break;
+                }
                 this.goTo("/exception/404");
                 break;
             case 403: //无权限

--- a/src/app/core/net/default.interceptor.ts
+++ b/src/app/core/net/default.interceptor.ts
@@ -259,9 +259,9 @@ export class DefaultInterceptor implements HttpInterceptor {
         //         }
         //     }
         // }
-
         const newReq = req.clone({
-            url: url
+            url: url,
+            headers: req.headers.set("lang", this.i18n.currentLang || '')
         });
         return next.handle(newReq).pipe(
             mergeMap((event: any) => {

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -82,21 +82,13 @@ export class DataService {
         }
     }
 
-    getCommonHeader(): any {
-        return {
-            lang: this.i18n.currentLang || '',
-        };
-    }
-
-
     //获取结构
     getEruptBuild(eruptName: string, eruptParentName?: string): Observable<EruptBuildModel> {
         return this._http.get<EruptBuildModel>(RestPath.build + "/" + eruptName, null, {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParentName || '',
-                ...this.getCommonHeader()
+                eruptParent: eruptParentName || ''
             }
         });
     }
@@ -106,8 +98,7 @@ export class DataService {
         return this._http.post(RestPath.data + "/extra-row/" + eruptName, condition, null, {
             observe: 'body',
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -117,8 +108,7 @@ export class DataService {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParentName || '',
-                ...this.getCommonHeader()
+                eruptParent: eruptParentName || ''
             }
         });
     }
@@ -148,8 +138,7 @@ export class DataService {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                ...header,
-                ...this.getCommonHeader()
+                ...header
             }
         });
     }
@@ -160,8 +149,7 @@ export class DataService {
         return this._http.get<Tree[]>(RestPath.data + "/tree/" + eruptName, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -171,8 +159,7 @@ export class DataService {
         return this._http.get<any>(RestPath.data + "/" + eruptName + "/" + id, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -184,7 +171,6 @@ export class DataService {
             headers: {
                 erupt: eruptName,
                 eruptParent: eruptParentName || '',
-                ...this.getCommonHeader(),
                 ...header
             }
         });
@@ -197,8 +183,7 @@ export class DataService {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParentName || '',
-                ...this.getCommonHeader()
+                eruptParent: eruptParentName || ''
             }
         });
     }
@@ -208,8 +193,7 @@ export class DataService {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParentName || '',
-                ...this.getCommonHeader()
+                eruptParent: eruptParentName || ''
             }
         });
     }
@@ -219,8 +203,7 @@ export class DataService {
             observe: "body",
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParentName || '',
-                ...this.getCommonHeader()
+                eruptParent: eruptParentName || ''
             }
         });
     }
@@ -230,8 +213,7 @@ export class DataService {
         return this._http.get<Tree[]>(RestPath.data + "/tab/tree/" + eruptName + "/" + tabFieldName, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -240,11 +222,23 @@ export class DataService {
         return this._http.get<Checkbox[]>(RestPath.data + "/" + eruptName + "/checkbox/" + fieldName, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
+
+    //自定义按钮表单初始值
+    operatorFormValue(eruptName: string, operatorCode: string, ids: any): Observable<any> {
+        return this._http.post(RestPath.data + "/" + eruptName + "/operator/" + operatorCode + "/form-value", null, {
+            ids: ids
+        }, {
+            observe: "body",
+            headers: {
+                erupt: eruptName
+            }
+        });
+    }
+
 
     //执行自定义operator方法
     execOperatorFun(eruptName: string, operatorCode: string, ids: any, param: object): Observable<EruptApiModel> {
@@ -254,8 +248,7 @@ export class DataService {
         }, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -264,8 +257,7 @@ export class DataService {
         return this._http.get<Tree[]>(RestPath.data + "/depend-tree/" + eruptName, null, {
             observe: "body",
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -277,8 +269,7 @@ export class DataService {
             param["dependValue"] = dependVal;
         }
         let header = {
-            erupt: eruptName,
-            ...this.getCommonHeader()
+            erupt: eruptName
         };
         if (eruptParent) {
             header["eruptParent"] = eruptParent;
@@ -295,8 +286,7 @@ export class DataService {
         return this._http.post<any>(RestPath.data + "/add/" + eruptName + "/drill/" + code + "/" + val, data, null, {
             observe: null,
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -307,8 +297,7 @@ export class DataService {
             observe: null,
             headers: {
                 erupt: eruptName,
-                ...headers,
-                ...this.getCommonHeader()
+                ...headers
             }
         });
     }
@@ -318,8 +307,7 @@ export class DataService {
         return this._http.post<EruptApiModel>(RestPath.dataModify + "/" + eruptName + "/update", data, null, {
             observe: null,
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -333,8 +321,7 @@ export class DataService {
     deleteEruptDataList(eruptName: string, ids: any[]): Observable<EruptApiModel> {
         return this._http.post(RestPath.dataModify + "/" + eruptName + "/delete", ids, null, {
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -343,8 +330,7 @@ export class DataService {
         return this._http.post(RestPath.data + "/validate-erupt/" + eruptName, data, null, {
             headers: {
                 erupt: eruptName,
-                eruptParent: eruptParent || "",
-                ...this.getCommonHeader()
+                eruptParent: eruptParent || ""
             }
         });
     }
@@ -352,8 +338,7 @@ export class DataService {
     eruptTabAdd(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
         return this._http.post(RestPath.dataModify + "/tab-add/" + eruptName + "/" + tabName, data, null, {
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -361,8 +346,7 @@ export class DataService {
     eruptTabUpdate(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
         return this._http.post(RestPath.dataModify + "/tab-update/" + eruptName + "/" + tabName, data, null, {
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -370,8 +354,7 @@ export class DataService {
     eruptTabDelete(eruptName: string, tabName: string, data: any): Observable<EruptApiModel> {
         return this._http.post(RestPath.dataModify + "/tab-delete/" + eruptName + "/" + tabName, data, null, {
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         });
     }
@@ -412,8 +395,7 @@ export class DataService {
     //获取菜单
     getMenu(): Observable<MenuVo[]> {
         return this._http.get<MenuVo[]>(RestPath.erupt + "/menu", null, {
-            observe: "body",
-            headers: this.getCommonHeader()
+            observe: "body"
         });
     }
 
@@ -426,8 +408,7 @@ export class DataService {
             responseType: "arraybuffer",
             observe: 'events',
             headers: {
-                erupt: eruptName,
-                ...this.getCommonHeader()
+                erupt: eruptName
             }
         }).subscribe((res) => {
             if (res.type !== 4) {
@@ -448,8 +429,7 @@ export class DataService {
             observe: 'events',
             headers: {
                 erupt: eruptName,
-                ...header,
-                ...this.getCommonHeader()
+                ...header
             }
         }).subscribe((res) => {
             if (res.type !== 4) {


### PR DESCRIPTION
🧩 处理 LambdaQuery eq 方法泛型限制不准确的 bug
🧩 处理查看详情场景子对象 long 类型精度丢失的问题
🌟 增加一对一组件的代码生成
🌟 解决在跨域场景下文件无法正常下载的 bug
🌟 自定义按钮支持从已选数据中初始化 eruptClass 表单值
🌟 Layout 注解增加 refreshTime 配置，用于控制页面接口数据自动更新控制
🌟 下钻支持自定义条件语法格式：类型.字段名，支持 and or等拼接语法 @Drill → @link → linkCondition
🌟 Lambda Query 支持聚合函数查询：count、sum、avg、min、max