### PR TITLE
1.12.14

### DIFF
--- a/src/app/build/erupt/components/choice/choice.component.html
+++ b/src/app/build/erupt/components/choice/choice.component.html
@@ -2,7 +2,7 @@
     <ng-container [ngSwitch]="eruptField.eruptFieldJson.edit.choiceType.type">
         <ng-container *ngSwitchCase="choiceEnum.RADIO">
             <nz-radio-group [(ngModel)]="eruptField.eruptFieldJson.edit.$value"
-                            [name]="eruptField.fieldName"
+                            [name]="eruptField.fieldName" (ngModelChange)="valueChange($event)"
                             class="erupt-input stander-line-height">
                 <ng-container *ngIf="checkAll">
                     <label nz-radio [nzValue]="">{{ 'global.all'|translate }}</label>
@@ -19,6 +19,7 @@
                        (nzOpenChange)="load($event)" [nzLoading]="isLoading"
                        [nzDisabled]="readonly" nzAllowClear
                        [(ngModel)]="eruptField.eruptFieldJson.edit.$value"
+                       (ngModelChange)="valueChange($event)"
                        [nzPlaceHolder]="eruptField.eruptFieldJson.edit.placeHolder"
                        [name]="eruptField.fieldName" [nzSize]="size" [nzShowSearch]="true">
                 <ng-container *ngIf="!isLoading">

--- a/src/app/build/erupt/components/choice/choice.component.ts
+++ b/src/app/build/erupt/components/choice/choice.component.ts
@@ -5,6 +5,7 @@ import {EruptModel} from "../../model/erupt.model";
 import {ChoiceEnum} from "../../model/erupt.enum";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {I18NService} from "@core";
+import {EditTypeComponent} from "../edit-type/edit-type.component";
 
 @Component({
     selector: 'erupt-choice',
@@ -18,7 +19,7 @@ export class ChoiceComponent implements OnInit {
 
     @Input() eruptField: EruptFieldModel;
 
-    @Input() size;
+    @Input() editType: EditTypeComponent;
 
     @Input() eruptParentName: string;
 
@@ -27,6 +28,8 @@ export class ChoiceComponent implements OnInit {
     @Input() readonly: boolean = false;
 
     @Input() checkAll: boolean = false;
+
+    @Input() size: 'large' | 'small' | "default" = "default";
 
     //是否开启联动功能
     @Input() dependLinkage = true;
@@ -53,6 +56,20 @@ export class ChoiceComponent implements OnInit {
         }
         if (!this.dependLinkage || !choiceType.dependField) {
             this.choiceVL = this.eruptField.componentValue
+        }
+    }
+
+    valueChange(val: any) {
+        if (this.eruptField.eruptFieldJson.edit.choiceType.trigger) {
+            if (this.editType) {
+                this.isLoading = true;
+                this.dataService.choiceTrigger(this.eruptModel.eruptName, this.eruptField.fieldName, val, this.eruptParentName).subscribe(data => {
+                    if (data) {
+                        this.editType.fillForm(data);
+                    }
+                    this.isLoading = false;
+                })
+            }
         }
     }
 

--- a/src/app/build/erupt/components/edit-type/edit-type.component.html
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.html
@@ -179,7 +179,7 @@
                                         [required]="field.eruptFieldJson.edit.notNull"
                                         [optionalHelp]="field.eruptFieldJson.edit.desc">
                                         <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
-                                                      [eruptParentName]="parentEruptName"
+                                                      [eruptParentName]="parentEruptName" [editType]="this"
                                                       [readonly]="isReadonly(field)" #choice>
 
                                         </erupt-choice>
@@ -195,7 +195,7 @@
                                         [required]="field.eruptFieldJson.edit.notNull"
                                         [optionalHelp]="field.eruptFieldJson.edit.desc">
                                         <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
-                                                      [eruptParentName]="parentEruptName"
+                                                      [eruptParentName]="parentEruptName" [editType]="this"
                                                       [readonly]="isReadonly(field)" #choice>
 
                                         </erupt-choice>

--- a/src/app/build/erupt/components/edit-type/edit-type.component.ts
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.ts
@@ -220,6 +220,15 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
         return accept.map(it => '.' + it)
     }
 
+    //根据后端数据填充字段表单
+    fillForm(data: any) {
+        for (let key in data) {
+            if (this.eruptModel.eruptFieldModelMap.get(key)) {
+                this.eruptModel.eruptFieldModelMap.get(key).eruptFieldJson.edit.$value = data[key];
+            }
+        }
+    }
+
 
     iframeHeight = IframeHeight;
 

--- a/src/app/build/erupt/model/erupt-field.model.ts
+++ b/src/app/build/erupt/model/erupt-field.model.ts
@@ -153,6 +153,7 @@ interface ChoiceType {
     dependField: string;
     dependExpr: string;
     items: VL[],
+    trigger: string;
 
     onVLChange(value, oldValue): void;
 }

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -1,5 +1,5 @@
 import {EruptBuildModel} from "../model/erupt-build.model";
-import {DateEnum, EditType, ViewType} from "../model/erupt.enum";
+import {DateEnum, EditType, PagingType, ViewType} from "../model/erupt.enum";
 import {ViewTypeComponent} from "../components/view-type/view-type.component";
 import {MarkdownComponent} from "../components/markdown/markdown.component";
 import {CodeEditorComponent} from "../components/code-editor/code-editor.component";
@@ -597,6 +597,17 @@ export class UiBuildService {
                     });
                     ref.getContentComponent().url = url;
                 };
+            }
+            if (layout.pagingType == PagingType.BACKEND) {
+                if (view.sortable) {
+                    obj.sort = {
+                        compare: null,
+                        reName: {
+                            ascend: 'asc',
+                            descend: 'desc'
+                        }
+                    }
+                }
             }
             if (layout) {
                 if (i < layout.tableLeftFixed) {

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -824,7 +824,7 @@ export class TableComponent implements OnInit, OnDestroy {
         }
         if (event.type == "sort") {
             let layout = this.eruptBuildModel.eruptModel.eruptJson.layout
-            if (layout && layout.pagingType && layout.pagingType != 'BACKEND') {
+            if (layout && layout.pagingType && layout.pagingType != PagingType.BACKEND) {
                 return;
             }
             this.query(1, this.dataPage.ps, event.sort.map);

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -188,6 +188,18 @@ export class DataService {
         });
     }
 
+    choiceTrigger(eruptName: string, field: string, val: any, eruptParentName?: string): any {
+        return this._http.get<any>(RestPath.component + "/choice-trigger/" + eruptName + "/" + field, {
+            val: val
+        }, {
+            observe: "body",
+            headers: {
+                erupt: eruptName,
+                eruptParent: eruptParentName || ''
+            }
+        });
+    }
+
     findChoiceItem(eruptName: string, field: string, eruptParentName?: string): Observable<VL[]> {
         return this._http.get<VL[]>(RestPath.component + "/choice-item/" + eruptName + "/" + field, null, {
             observe: "body",


### PR DESCRIPTION
🐞 解决部分菜单名称 i18n 失效的问题
🐞 修复自定义 BUTTON 类按钮，关联 eruptClass表单，表单值报错的问题
🐞 修复分布式 node 获取组配置时报缺少请求头参数问题 与 node获取当前用户时404的问题 [#28](https://gitee.com/erupt/erupt/pulls/28) 感谢 [shareloke](https://gitee.com/shareloke) 贡献的代码
🐞 解决 oneToOne在存储 json 场景时 view报错的 bug吧🐞 解决排序时，后端排序结果会被前端重排的bug
🧩 优化修改菜单管理中 erupt 类名调整触发的代码逻辑，不会出现角色绑定异常的问题
🌟 @erupt注解增加dataProxyParams配置，PreDataProxy注解增加params配置，此值可在dataProxy内被DataProxyContext.get()方法中获取到，增强单个dataProxy的通用性
🌟 erupt 注解支持[热构建](https://www.yuque.com/erupts/erupt/cuviefw0cq90hclm)，修改注解值无需重启服务
🌟 choice 组件支持 [trigger](https://www.yuque.com/erupts/erupt/pd5xn9#HNqh7) 配置，选择组件值可以填充到其他组件
🌟 重构 [erupt-job](https://www.yuque.com/erupts/erupt/dyx3r9) 模块，支持多机集群部署
🌟 erupt-job EruptJobHandler 支持定义名称、Cron、运行参数，且支持带入到界面
🌟 erupt-job 支持手动运行时填入执行参数
🌟 EruptLambdaQuery 支持 condition 语法，消除拼接时的 if
🌟 新增系统日志能力，可以实时看到服务内日志信息
🌟 erupt-cloud 支持查看节点内日志信息