### PR TITLE
1.12.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "erut-web",
     "version": "0.0.0",
-    "description": "erupt framework front-end",
+    "description": "erupt front-end",
     "author": "yuepeng <erupts@126.com>",
     "repository": {
         "type": "git",

--- a/src/app/build/erupt/components/checkbox/checkbox.component.html
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.html
@@ -8,4 +8,8 @@
             </div>
         </div>
     </nz-checkbox-wrapper>
+    <ng-container *ngIf="!checkbox || !checkbox.length">
+        <nz-empty [nzNotFoundImage]="'simple'" [nzNotFoundContent]="null">
+        </nz-empty>
+    </ng-container>
 </nz-spin>

--- a/src/app/build/erupt/components/checkbox/checkbox.component.less
+++ b/src/app/build/erupt/components/checkbox/checkbox.component.less
@@ -1,13 +1,14 @@
 :host {
-  ::ng-deep {
-    label[nz-checkbox] {
-      max-width: 140px;
-      line-height: initial;
-      margin-left: 0;
-      margin-bottom: 12px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+    ::ng-deep {
+        label[nz-checkbox] {
+            max-width: 140px;
+            line-height: initial;
+            margin-left: 0;
+            margin-bottom: 6px;
+            margin-top: 6px;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
     }
-  }
 }

--- a/src/app/build/erupt/components/view-type/view-type.component.ts
+++ b/src/app/build/erupt/components/view-type/view-type.component.ts
@@ -36,31 +36,37 @@ export class ViewTypeComponent implements OnInit, AfterViewInit {
     }
 
     ngOnInit() {
-        if (this.value) {
-            if (this.view.eruptFieldModel.eruptFieldJson.edit.type === EditType.ATTACHMENT) {
-                const attachmentType = this.view.eruptFieldModel.eruptFieldJson.edit.attachmentType;
-                let _paths = (<string>this.value).split(attachmentType.fileSeparator);
-                for (let path of _paths) {
-                    this.paths.push(DataService.previewAttachment(path));
+        switch (this.view.viewType) {
+            case ViewType.TAB_VIEW:
+                this.loading = true;
+                this.dataService.queryEruptDataById(this.eruptBuildModel.eruptModel.eruptName, this.value).subscribe(data => {
+                    this.dataHandler.objectToEruptValue(data, this.eruptBuildModel);
+                    this.loading = false;
+                });
+                break
+            case ViewType.ATTACHMENT_DIALOG:
+            case ViewType.ATTACHMENT:
+            case ViewType.DOWNLOAD:
+            case ViewType.IMAGE:
+            case ViewType.SWF:
+                if (this.value) {
+                    if (this.view.eruptFieldModel.eruptFieldJson.edit.type === EditType.ATTACHMENT) {
+                        const attachmentType = this.view.eruptFieldModel.eruptFieldJson.edit.attachmentType;
+                        let _paths = (<string>this.value).split(attachmentType.fileSeparator);
+                        for (let path of _paths) {
+                            this.paths.push(DataService.previewAttachment(path));
+                        }
+                    } else {
+                        let _paths = (<string>this.value).split("|");
+                        for (let path of _paths) {
+                            this.paths.push(DataService.previewAttachment(path));
+                        }
+                    }
+                    if (this.view.viewType == ViewType.ATTACHMENT_DIALOG) {
+                        this.value = [DataService.previewAttachment(this.value)];
+                    }
                 }
-            } else {
-                let _paths = (<string>this.value).split("|");
-                for (let path of _paths) {
-                    this.paths.push(DataService.previewAttachment(path));
-                }
-            }
-            switch (this.view.viewType) {
-                case ViewType.ATTACHMENT_DIALOG:
-                    this.value = [DataService.previewAttachment(this.value)];
-                    break;
-            }
-        }
-        if (this.view.viewType === ViewType.TAB_VIEW) {
-            this.loading = true;
-            this.dataService.queryEruptDataById(this.eruptBuildModel.eruptModel.eruptName, this.value).subscribe(data => {
-                this.dataHandler.objectToEruptValue(data, this.eruptBuildModel);
-                this.loading = false;
-            });
+                break;
         }
     }
 

--- a/src/app/build/erupt/erupt.module.ts
+++ b/src/app/build/erupt/erupt.module.ts
@@ -39,6 +39,7 @@ import {SearchSeComponent} from "./components/search-se/search-se.component";
 import {NzQRCodeModule} from "ng-zorro-antd/qr-code";
 import {NzRateModule} from "ng-zorro-antd/rate";
 import {AttachmentSelectComponent} from './components/attachment-select/attachment-select.component';
+import {NzEmptyModule} from "ng-zorro-antd/empty";
 
 @NgModule({
     imports: [
@@ -51,7 +52,8 @@ import {AttachmentSelectComponent} from './components/attachment-select/attachme
         NzPipesModule,
         NzImageModule,
         NzQRCodeModule,
-        NzRateModule
+        NzRateModule,
+        NzEmptyModule
     ],
     providers: [
         DataHandlerService,

--- a/src/app/build/erupt/model/erupt.enum.ts
+++ b/src/app/build/erupt/model/erupt.enum.ts
@@ -118,7 +118,7 @@ export enum SelectMode {
 }
 
 export enum OperationMode {
-    SINGLE = "SINGLE", MULTI = "MULTI", BUTTON = "BUTTON"
+    SINGLE = "SINGLE", MULTI = "MULTI", BUTTON = "BUTTON", MULTI_ONLY = "MULTI_ONLY"
 }
 
 export enum OperationType {

--- a/src/app/build/erupt/model/erupt.vo.ts
+++ b/src/app/build/erupt/model/erupt.vo.ts
@@ -1,3 +1,7 @@
+export class TableStyle {
+    public static power = "__power__";
+}
+
 export interface QueryCondition {
     key: string;
     value: any;

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, Input, OnDestroy, OnInit, ViewChild} from "@angular/core";
 import {DataService} from "@shared/service/data.service";
-import {Drill, DrillInput, EruptModel, Row, RowOperation} from "../../model/erupt.model";
+import {Drill, DrillInput, EruptModel, Power, Row, RowOperation} from "../../model/erupt.model";
 
 import {SettingsService} from "@delon/theme";
 import {EditTypeComponent} from "../../components/edit-type/edit-type.component";
@@ -34,6 +34,7 @@ import {STChange, STPage} from "@delon/abc/st/st.interfaces";
 import {AppViewService} from "@shared/service/app-view.service";
 import {CodeEditorComponent} from "../../components/code-editor/code-editor.component";
 import {NzDrawerService} from "ng-zorro-antd/drawer";
+import {TableStyle} from "../../model/erupt.vo";
 
 
 @Component({
@@ -381,6 +382,12 @@ export class TableComponent implements OnInit, OnDestroy {
                         });
                         Object.assign(ref.getContentComponent(), params)
                     }
+                },
+                iif: (item) => {
+                    if (item[TableStyle.power]) {
+                        return (<Power>item[TableStyle.power]).viewDetails !== false
+                    }
+                    return true;
                 }
             });
         }
@@ -540,6 +547,12 @@ export class TableComponent implements OnInit, OnDestroy {
                         }
                     });
                     Object.assign(model.getContentComponent(), params)
+                },
+                iif: (item) => {
+                    if (item[TableStyle.power]) {
+                        return (<Power>item[TableStyle.power]).edit !== false
+                    }
+                    return true;
                 }
             });
         }
@@ -565,6 +578,12 @@ export class TableComponent implements OnInit, OnDestroy {
                                 this.msg.success(this.i18n.fanyi('global.delete.success'));
                             }
                         });
+                },
+                iif: (item) => {
+                    if (item[TableStyle.power]) {
+                        return (<Power>item[TableStyle.power]).delete !== false
+                    }
+                    return true;
                 }
             });
         }

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -401,7 +401,7 @@ export class TableComponent implements OnInit, OnDestroy {
         }
         for (let i in this.eruptBuildModel.eruptModel.eruptJson.rowOperation) {
             let ro = this.eruptBuildModel.eruptModel.eruptJson.rowOperation[i];
-            if (ro.mode !== OperationMode.BUTTON) {
+            if (ro.mode !== OperationMode.BUTTON && ro.mode !== OperationMode.MULTI_ONLY) {
                 let text = "";
                 if (ro.icon) {
                     text = `<i class=\"${ro.icon}\"></i>`;

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -309,7 +309,7 @@ export class TableComponent implements OnInit, OnDestroy {
             ...query
         }, this.header).subscribe(page => {
             this.dataPage.querying = false;
-            this.dataPage.data = page.list
+            this.dataPage.data = page.list || [];
             this.dataPage.total = page.total;
             // for (let ele of spliceArr(page.list, 20)) {
             //     this.dataPage.data.push(...ele)

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -589,14 +589,14 @@ export class TableComponent implements OnInit, OnDestroy {
      * @param rowOperation 行按钮对象
      * @param data 数据（单个执行时使用）
      */
-    createOperator(rowOperation: RowOperation, data?: object, reloadModal?: boolean) {
+    createOperator(rowOperation: RowOperation, data?: object) {
         const eruptModel = this.eruptBuildModel.eruptModel;
         const ro = rowOperation;
         let ids = [];
         if (data) {
             ids = [data[eruptModel.eruptJson.primaryKeyCol]];
         } else {
-            if (ro.mode === OperationMode.MULTI && this.selectedRows.length === 0) {
+            if ((ro.mode === OperationMode.MULTI || ro.mode === OperationMode.MULTI_ONLY) && this.selectedRows.length === 0) {
                 this.msg.warning(this.i18n.fanyi("table.require.select_one"));
                 return;
             }

--- a/src/app/layout/erupt/erupt.component.ts
+++ b/src/app/layout/erupt/erupt.component.ts
@@ -265,6 +265,7 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
             }
             this.settingsService.setUser({
                 name: userinfo.nickname,
+                tenantName: userinfo.tenantName || null,
                 indexPath: path
             });
             if (this.router.url === "/") {

--- a/src/app/layout/erupt/erupt.component.ts
+++ b/src/app/layout/erupt/erupt.component.ts
@@ -1,7 +1,6 @@
 import {
     AfterViewInit,
     Component,
-    ComponentFactoryResolver,
     ElementRef,
     Inject,
     OnDestroy,
@@ -12,18 +11,11 @@ import {
     ViewContainerRef
 } from "@angular/core";
 import {DOCUMENT} from "@angular/common";
-import {
-    ActivatedRoute,
-    NavigationCancel,
-    NavigationEnd,
-    NavigationError,
-    RouteConfigLoadStart,
-    Router
-} from "@angular/router";
+import {NavigationCancel, NavigationEnd, NavigationError, RouteConfigLoadStart, Router} from "@angular/router";
 
-import {Subscription} from "rxjs";
+import {Observable, Subscription} from "rxjs";
 import {ScrollService, updateHostClass} from "@delon/util";
-import {Menu, MenuService, SettingsService, TitleService} from "@delon/theme";
+import {Menu, MenuService, SettingsService} from "@delon/theme";
 import {
     ArrowDownOutline,
     BellOutline,
@@ -42,17 +34,18 @@ import {
 } from "@ant-design/icons-angular/icons";
 import {DataService} from "@shared/service/data.service";
 import {environment} from "@env/environment";
-import {DA_SERVICE_TOKEN, TokenService} from "@delon/auth";
 import {generateMenuPath} from "@shared/util/erupt.util";
 import {MenuTypeEnum, MenuVo} from "@shared/model/erupt-menu";
 import {I18NService} from "@core";
-import {StatusService} from "@shared/service/status.service";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {NzIconService} from "ng-zorro-antd/icon";
 import {ResetPwdComponent} from "../../routes/reset-pwd/reset-pwd.component";
 import {ReuseTabService} from "@delon/abc/reuse-tab";
 import {EruptAppData} from "@shared/model/erupt-app.model";
+import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
+import {Userinfo} from "@shared/model/user.model";
+import {UtilsService} from "@shared/service/utils.service";
 
 // #region icons
 
@@ -108,21 +101,18 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
                 private router: Router,
                 scroll: ScrollService,
                 _message: NzMessageService,
-                private resolver: ComponentFactoryResolver,
                 public menuSrv: MenuService,
                 public settings: SettingsService,
                 private el: ElementRef,
                 private renderer: Renderer2,
                 public settingSrv: SettingsService,
-                public route: ActivatedRoute,
                 public data: DataService,
                 private settingsService: SettingsService,
-                private statusService: StatusService,
                 @Inject(NzModalService)
                 private modal: NzModalService,
-                private titleService: TitleService,
+                @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService,
                 private i18n: I18NService,
-                @Inject(DA_SERVICE_TOKEN) private tokenService: TokenService,
+                private utilsService: UtilsService,
                 @Optional()
                 @Inject(ReuseTabService)
                 private reuseTabService: ReuseTabService,
@@ -194,32 +184,6 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
     ngOnInit() {
         this.notify$ = this.settings.notify.subscribe(() => this.setClass());
         this.setClass();
-        this.data.getUserinfo().subscribe(userinfo => {
-            let path = generateMenuPath(userinfo.indexMenuType, userinfo.indexMenuValue);
-            if (EruptAppData.get().waterMark) {
-                this.nickName = userinfo.nickname;
-            }
-            this.settingsService.setUser({
-                name: userinfo.nickname,
-                indexPath: path
-            });
-            if (this.router.url === "/") {
-                path && this.router.navigateByUrl(path).then();
-            }
-            if (userinfo.resetPwd && EruptAppData.get().resetPwd) {
-                this.modal.create({
-                    nzTitle: this.i18n.fanyi("global.reset_pwd"),
-                    nzMaskClosable: false,
-                    nzClosable: true,
-                    nzKeyboard: true,
-                    nzContent: ResetPwdComponent,
-                    nzFooter: null,
-                    nzBodyStyle: {
-                        paddingBottom: '1px'
-                    }
-                });
-            }
-        });
         this.data.getMenu().subscribe(res => {
             this.menu = res;
 
@@ -284,6 +248,39 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
                     setTimeout(() => {
                         ele.removeChild(spanRipper);
                     }, 800);
+                });
+            }
+        });
+        let userinfoObservable: Observable<Userinfo>;
+
+        if (this.utilsService.isTenantToken()) {
+            userinfoObservable = this.data.tenantUserinfo()
+        } else {
+            userinfoObservable = this.data.userinfo();
+        }
+        userinfoObservable.subscribe(userinfo => {
+            let path = generateMenuPath(userinfo.indexMenuType, userinfo.indexMenuValue);
+            if (EruptAppData.get().waterMark) {
+                this.nickName = userinfo.nickname;
+            }
+            this.settingsService.setUser({
+                name: userinfo.nickname,
+                indexPath: path
+            });
+            if (this.router.url === "/") {
+                path && this.router.navigateByUrl(path).then();
+            }
+            if (userinfo.resetPwd && EruptAppData.get().resetPwd) {
+                this.modal.create({
+                    nzTitle: this.i18n.fanyi("global.reset_pwd"),
+                    nzMaskClosable: false,
+                    nzClosable: true,
+                    nzKeyboard: true,
+                    nzContent: ResetPwdComponent,
+                    nzFooter: null,
+                    nzBodyStyle: {
+                        paddingBottom: '1px'
+                    }
                 });
             }
         });

--- a/src/app/layout/erupt/header/components/user.component.ts
+++ b/src/app/layout/erupt/header/components/user.component.ts
@@ -20,7 +20,7 @@ import {UtilsService} from "@shared/service/utils.service";
             <span class="hidden-mobile">{{ settings.user.name }}</span>
         </div>
         <nz-dropdown-menu #avatarMenu>
-            <div nz-menu class="width-sm">
+            <div nz-menu class="width-sm" style="padding: 0">
                 <div *ngIf="settings.user['tenantName']" style="padding: 8px 12px;border-bottom:1px solid #eee">
                     {{ settings.user['tenantName'] }}
                 </div>

--- a/src/app/layout/erupt/header/components/user.component.ts
+++ b/src/app/layout/erupt/header/components/user.component.ts
@@ -8,6 +8,7 @@ import {WindowModel} from "@shared/model/window.model";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {ResetPwdComponent} from "../../../../routes/reset-pwd/reset-pwd.component";
 import {EruptAppData} from "@shared/model/erupt-app.model";
+import {UtilsService} from "@shared/service/utils.service";
 
 @Component({
     selector: "header-user",
@@ -16,15 +17,15 @@ import {EruptAppData} from "@shared/model/erupt-app.model";
              [nzDropdownMenu]="avatarMenu">
             <nz-avatar [nzText]="settings.user.name&&settings.user.name.substr(0,1)" nzSize="default"
                        class="mr-sm"></nz-avatar>
-            <span class="hidden-mobile">{{settings.user.name}}</span>
+            <span class="hidden-mobile">{{ settings.user.name }}</span>
         </div>
         <nz-dropdown-menu #avatarMenu>
             <div nz-menu class="width-sm">
-                <div nz-menu-item (click)="changePwd()"  *ngIf="resetPassword">
-                    <i nz-icon nzType="edit" nzTheme="fill" class="mr-sm"></i>{{'global.reset_pwd'|translate}}
+                <div nz-menu-item (click)="changePwd()" *ngIf="resetPassword">
+                    <i nz-icon nzType="edit" nzTheme="fill" class="mr-sm"></i>{{ 'global.reset_pwd'|translate }}
                 </div>
                 <div nz-menu-item (click)="logout()">
-                    <i nz-icon nzType="logout" nzTheme="outline" class="mr-sm"></i>{{'global.logout'|translate}}
+                    <i nz-icon nzType="logout" nzTheme="outline" class="mr-sm"></i>{{ 'global.logout'|translate }}
                 </div>
             </div>
         </nz-dropdown-menu>
@@ -33,7 +34,7 @@ import {EruptAppData} from "@shared/model/erupt-app.model";
 export class HeaderUserComponent {
 
     resetPassword = EruptAppData.get().resetPwd;
- 
+
     constructor(
         public settings: SettingsService,
         private router: Router,
@@ -42,6 +43,7 @@ export class HeaderUserComponent {
         private dataService: DataService,
         @Inject(NzModalService)
         private modal: NzModalService,
+        private utilsService: UtilsService
     ) {
     }
 
@@ -50,14 +52,18 @@ export class HeaderUserComponent {
             nzTitle: this.i18n.fanyi("global.confirm_logout"),
             nzOnOk: () => {
                 this.dataService.logout().subscribe(data => {
+                    let token = this.tokenService.get().token;
                     if (WindowModel.eruptEvent && WindowModel.eruptEvent.logout) {
                         WindowModel.eruptEvent.logout({
                             userName: this.settings.user.name,
-                            token: this.tokenService.get().token
+                            token: token
                         })
                     }
-                    this.tokenService.clear();
-                    this.router.navigateByUrl(this.tokenService.login_url);
+                    if (this.utilsService.isTenantToken()) {
+                        this.router.navigateByUrl("/passport/tenant");
+                    } else {
+                        this.router.navigateByUrl(this.tokenService.login_url);
+                    }
                 });
             }
         });

--- a/src/app/layout/erupt/header/components/user.component.ts
+++ b/src/app/layout/erupt/header/components/user.component.ts
@@ -21,6 +21,9 @@ import {UtilsService} from "@shared/service/utils.service";
         </div>
         <nz-dropdown-menu #avatarMenu>
             <div nz-menu class="width-sm">
+                <div *ngIf="settings.user['tenantName']" style="padding: 8px 12px;border-bottom:1px solid #eee">
+                    {{ settings.user['tenantName'] }}
+                </div>
                 <div nz-menu-item (click)="changePwd()" *ngIf="resetPassword">
                     <i nz-icon nzType="edit" nzTheme="fill" class="mr-sm"></i>{{ 'global.reset_pwd'|translate }}
                 </div>

--- a/src/app/layout/passport/login/login.component.ts
+++ b/src/app/layout/passport/login/login.component.ts
@@ -57,7 +57,7 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
         @Inject(DA_SERVICE_TOKEN) private tokenService: TokenService,
         private cacheService: CacheService
     ) {
-        this.tenantLogin = !!EruptAppData.get().properties["erupt-tenant"]
+        this.tenantLogin = !!(EruptAppData.get().properties && EruptAppData.get().properties["erupt-tenant"])
         this.form = fb.group({
             userName: [null, [Validators.required, Validators.minLength(1)]],
             password: [null, Validators.required],

--- a/src/app/layout/passport/login/login.component.ts
+++ b/src/app/layout/passport/login/login.component.ts
@@ -72,9 +72,6 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
         if (EruptAppData.get().loginPagePath) {
             window.location.href = EruptAppData.get().loginPagePath;
         }
-        if (WindowModel.eruptRouterEvent.login) {
-            WindowModel.eruptRouterEvent.login.load();
-        }
     }
 
     ngAfterViewInit(): void {
@@ -175,8 +172,6 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
     }
 
     ngOnDestroy(): void {
-        if (WindowModel.eruptRouterEvent.login) {
-            WindowModel.eruptRouterEvent.login.unload();
-        }
+
     }
 }

--- a/src/app/layout/passport/passport.component.html
+++ b/src/app/layout/passport/passport.component.html
@@ -14,7 +14,6 @@
         </div>
         <div style="display: flex; justify-content: center;">
             <div class="pass-form">
-                <h3 style="margin-bottom: 26px;text-align: center">{{'login.account_pwd_login'|translate}}</h3>
                 <router-outlet></router-outlet>
             </div>
         </div>

--- a/src/app/layout/passport/tenant-login/tenant-login.component.html
+++ b/src/app/layout/passport/tenant-login/tenant-login.component.html
@@ -1,6 +1,13 @@
-<h3 style="margin-bottom: 26px;text-align: center">{{'login.account_pwd_login'|translate}}</h3>
+<h3 style="margin-bottom: 26px;text-align: center">{{ '租户登录'|translate }}</h3>
 <form nz-form [formGroup]="form" (ngSubmit)="submit()" role="form">
     <nz-alert *ngIf="error" [nzType]="'error'" [nzMessage]="error" [nzShowIcon]="true" class="mb-lg"></nz-alert>
+    <nz-form-item>
+        <nz-form-control>
+            <nz-input-group nzSize="large" nzPrefixIcon="apartment">
+                <input nz-input formControlName="tenantCode" [placeholder]="'企业ID'">
+            </nz-input-group>
+        </nz-form-control>
+    </nz-form-item>
     <!--账号-->
     <nz-form-item>
         <nz-form-control [nzErrorTip]="accountTip">
@@ -61,6 +68,6 @@
         </button>
     </nz-form-item>
     <p style="text-align: center;margin-top: 16px;">
-        <a *ngIf="tenantLogin" (click)="toTenant()">{{ '租户登录' }}</a>
+        <a *ngIf="tenantLogin" (click)="toLogin()">{{ '平台登录' }}</a>
     </p>
 </form>

--- a/src/app/layout/passport/tenant-login/tenant-login.component.less
+++ b/src/app/layout/passport/tenant-login/tenant-login.component.less
@@ -1,0 +1,28 @@
+@import '@delon/theme/theme-default.less';
+
+:host {
+    display: block;
+    max-width: 368px;
+    margin: 0 auto;
+
+    ::ng-deep {
+
+        .ant-input-affix-wrapper .ant-input:not(:first-child) {
+            padding-left: 8px;
+        }
+
+        .icon {
+            font-size: 24px;
+            color: rgba(0, 0, 0, 0.2);
+            margin-left: 16px;
+            vertical-align: middle;
+            cursor: pointer;
+            transition: color 0.3s;
+
+            &:hover {
+                color: @primary-color;
+            }
+        }
+
+    }
+}

--- a/src/app/layout/passport/tenant-login/tenant-login.component.ts
+++ b/src/app/layout/passport/tenant-login/tenant-login.component.ts
@@ -9,7 +9,6 @@ import {Md5} from "ts-md5";
 import {WindowModel} from "@shared/model/window.model";
 import {I18NService} from "@core";
 import {NzMessageService} from "ng-zorro-antd/message";
-import {NzModalService} from "ng-zorro-antd/modal";
 import {ReuseTabService} from "@delon/abc/reuse-tab";
 import {EruptAppData} from "@shared/model/erupt-app.model";
 
@@ -46,8 +45,6 @@ export class UserTenantLoginComponent implements OnDestroy, OnInit, AfterViewIni
         private data: DataService,
         private router: Router,
         public msg: NzMessageService,
-        @Inject(NzModalService)
-        private modal: NzModalService,
         private i18n: I18NService,
         @Optional()
         @Inject(ReuseTabService)
@@ -70,9 +67,6 @@ export class UserTenantLoginComponent implements OnDestroy, OnInit, AfterViewIni
     ngOnInit(): void {
         if (EruptAppData.get().loginPagePath) {
             window.location.href = EruptAppData.get().loginPagePath;
-        }
-        if (WindowModel.eruptRouterEvent.login) {
-            WindowModel.eruptRouterEvent.login.load();
         }
     }
 
@@ -173,8 +167,5 @@ export class UserTenantLoginComponent implements OnDestroy, OnInit, AfterViewIni
     }
 
     ngOnDestroy(): void {
-        if (WindowModel.eruptRouterEvent.login) {
-            WindowModel.eruptRouterEvent.login.unload();
-        }
     }
 }

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -11,6 +11,7 @@ import {HomeComponent} from "./home/home.component";
 import {FillComponent} from "./fill/fill.component";
 import {SiteComponent} from "./site/site.component";
 import {LayoutEruptComponent} from "../layout/erupt/erupt.component";
+import {UserTenantLoginComponent} from "../layout/passport/tenant-login/tenant-login.component";
 
 // layout
 let coreRouter: Routes = [
@@ -61,6 +62,7 @@ const routes: Routes = [
         component: LayoutPassportComponent,
         children: [
             {path: "login", component: UserLoginComponent, data: {title: "Login"}},
+            {path: "tenant", component: UserTenantLoginComponent, data: {title: "Login"}},
         ]
     },
     // 全屏布局

--- a/src/app/routes/routes.module.ts
+++ b/src/app/routes/routes.module.ts
@@ -8,8 +8,9 @@ import {UserLoginComponent} from "../layout/passport/login/login.component";
 import {LayoutModule} from "../layout/layout.module";
 import {FillComponent} from "./fill/fill.component";
 import {ResetPwdComponent} from "./reset-pwd/reset-pwd.component";
+import {UserTenantLoginComponent} from "../layout/passport/tenant-login/tenant-login.component";
 
-const COMPONENTS: Array<Type<any>> = [SiteComponent, FillComponent, HomeComponent, ResetPwdComponent, UserLoginComponent];
+const COMPONENTS: Array<Type<any>> = [SiteComponent, FillComponent, HomeComponent, ResetPwdComponent, UserLoginComponent, UserTenantLoginComponent];
 
 @NgModule({
     imports: [SharedModule, RouteRoutingModule, LayoutModule],

--- a/src/app/shared/model/erupt-app.model.ts
+++ b/src/app/shared/model/erupt-app.model.ts
@@ -7,6 +7,7 @@ export interface EruptAppModel {
     loginPagePath: string;
     waterMark: boolean;
     resetPwd: boolean;
+    properties: object;
 }
 
 let eruptAppConfig: EruptAppModel = window["eruptApp"] || {};

--- a/src/app/shared/model/user.model.ts
+++ b/src/app/shared/model/user.model.ts
@@ -11,4 +11,5 @@ export interface Userinfo {
     indexMenuType: string;
     indexMenuValue: string;
     resetPwd: boolean;
+    tenantId: string;
 }

--- a/src/app/shared/model/user.model.ts
+++ b/src/app/shared/model/user.model.ts
@@ -12,4 +12,5 @@ export interface Userinfo {
     indexMenuValue: string;
     resetPwd: boolean;
     tenantId: string;
+    tenantName: string;
 }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -382,6 +382,17 @@ export class DataService {
         );
     }
 
+    tenantLogin(tenantCode: string, account: string, pwd: string, verifyCode?: any, verifyCodeMark?: any): Observable<LoginModel> {
+        return this._http.get(RestPath.erupt + "/tenant/login", {
+                tenantCode: tenantCode,
+                account: account,
+                pwd: pwd,
+                verifyCode: verifyCode,
+                verifyCodeMark: verifyCodeMark || null
+            }
+        );
+    }
+
     logout(): Observable<any> {
         return this._http.get(RestPath.erupt + "/logout");
     }

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -393,6 +393,19 @@ export class DataService {
         );
     }
 
+    tenantChangePwd(pwd: string, newPwd: string, newPwd2: string): Observable<EruptApiModel> {
+        return this._http.get(RestPath.erupt + "/tenant/change-pwd", {
+                pwd: this.pwdEncode(pwd, 3),
+                newPwd: this.pwdEncode(newPwd, 3),
+                newPwd2: this.pwdEncode(newPwd2, 3)
+            }
+        );
+    }
+
+    tenantUserinfo(): Observable<Userinfo> {
+        return this._http.get<Userinfo>(RestPath.erupt + "/tenant/userinfo");
+    }
+
     logout(): Observable<any> {
         return this._http.get(RestPath.erupt + "/logout");
     }
@@ -422,7 +435,7 @@ export class DataService {
         });
     }
 
-    getUserinfo(): Observable<Userinfo> {
+    userinfo(): Observable<Userinfo> {
         return this._http.get<Userinfo>(RestPath.erupt + "/userinfo");
     }
 

--- a/src/app/shared/service/erupt-context.service.ts
+++ b/src/app/shared/service/erupt-context.service.ts
@@ -1,0 +1,21 @@
+import {Injectable} from "@angular/core";
+
+
+export enum ContextKey {
+
+}
+
+@Injectable()
+export class EruptContextService {
+
+    private contextValue = {};
+
+    set(key: ContextKey, value: any) {
+        this.contextValue[key] = value;
+    }
+
+    get(key: ContextKey) {
+        return this.contextValue[key];
+    }
+
+}

--- a/src/app/shared/service/erupt-storage.service.ts
+++ b/src/app/shared/service/erupt-storage.service.ts
@@ -46,7 +46,6 @@ export class EruptStorageService {
             data = JSON.parse(dataStr);
         }
         data[key] = query;
-        console.log(code)
         localStorage.setItem(code, JSON.stringify(data));
     }
 

--- a/src/app/shared/service/utils.service.ts
+++ b/src/app/shared/service/utils.service.ts
@@ -1,21 +1,29 @@
 /**
  * Created by liyuepeng on 10/16/19.
  */
-import {Injectable} from "@angular/core";
+import {Inject, Injectable} from "@angular/core";
 import {LazyService} from "@delon/util";
+import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
 
 @Injectable()
 export class UtilsService {
 
-  constructor(private lazy: LazyService) {
-  }
+    constructor(
+        private lazy: LazyService,
+        @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService
+    ) {
+    }
 
-  async loadScript(src: string) {
-    await this.lazy.loadScript(src).then(res => res);
-  }
+    isTenantToken(): boolean {
+        return this.tokenService.get().token.split(".").length == 2
+    }
 
-  async loadStyle(src: string) {
-    await this.lazy.loadStyle(src).then(res => res);
-  }
+    async loadScript(src: string) {
+        await this.lazy.loadScript(src).then(res => res);
+    }
+
+    async loadStyle(src: string) {
+        await this.lazy.loadStyle(src).then(res => res);
+    }
 
 }

--- a/src/app/shared/service/utils.service.ts
+++ b/src/app/shared/service/utils.service.ts
@@ -15,7 +15,7 @@ export class UtilsService {
     }
 
     isTenantToken(): boolean {
-        return this.tokenService.get().token.split(".").length == 2
+        return this.tokenService.get().token.split(".").length == 3
     }
 
     async loadScript(src: string) {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -21,6 +21,8 @@ import {EruptStorageService} from "@shared/service/erupt-storage.service";
 import {StProgressComponent} from "@shared/component/st-progress/st-progress.component";
 import {STWidgetRegistry} from "@delon/abc/st";
 import {UEditorComponent} from "@shared/component/ueditor/ueditor.component";
+import {EruptContextService} from "@shared/service/erupt-context.service";
+import {UtilsService} from "@shared/service/utils.service";
 
 // #region third libs
 // import { NgxTinymceModule } from 'ngx-tinymce';
@@ -55,6 +57,8 @@ const DIRECTIVES: Array<Type<any>> = [RipperDirective, SafeHtmlPipe, SafeScriptP
     ],
     providers: [
         DataService,
+        UtilsService,
+        EruptContextService,
         EruptStorageService
     ],
     exports: [

--- a/src/style-icons-auto.ts
+++ b/src/style-icons-auto.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    ApartmentOutline,
     ArrowDownOutline,
     ArrowRightOutline,
     BuildOutline,
@@ -98,5 +99,6 @@ export const ICONS_AUTO = [
     UnorderedListOutline,
     UserOutline,
     ArrowRightOutline,
-    FileImageOutline
+    FileImageOutline,
+    ApartmentOutline
 ];


### PR DESCRIPTION
🐞 解决表格场景一对多不触发查询的bug
🧩 解决 excel 导入数值时，单元格格式为string无法正常导入的bug
🧩 修复 excel 导入时，部分场景出现最后一行空行导入空json的问题（感谢[hply](https://github.com/hply)贡献的代码） [#269](https://github.com/erupts/erupt/pull/269)
🧩 调整导出引擎为 XSSF ,倾向功能而且内存控制，允许dataProxy中的excelExport获得完成的内存数据
🧩 优化 checkbox UI无数据时不会空白显示
🧩 解决excel导入数值时数值过大会显示为科学计数法的问题
🧩 ifRender启动时不会自动执行，确保动态渲染函数在合适的时机执行
🧩 自定义按钮渲染默认是增加：[MULTI_ONLY](https://www.yuque.com/erupts/erupt/gaing7#UApIg)，该模式多行按钮不会显示在单行中
🧩 新增[DataProxyContext](https://www.yuque.com/erupts/erupt/nicqg3#VHBn6)工具类，支持在DataProxy中通过上下文的方式获取当前类对象与参数等数据
🌟 表格支持按[单元格设置颜色](https://www.yuque.com/erupts/erupt/nicqg3#EINcZ)
🌟 表格支持按行数据动态调整编辑与删除能力 [⚔️ 自定义数据逻辑（ DataProxy ）](https://www.yuque.com/erupts/erupt/nicqg3#BPV07)
🌟 新增多租户插件，适合企业开发SaaS应用 [多租户 erupt-tenant](https://www.yuque.com/erupts/erupt/xviwe9bimrmae26t)