### PR TITLE
1.12.17

### DIFF
--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -16,5 +16,11 @@ module.exports = {
         // target: 'https://www.erupt.xyz/demo',
         // secure: true, // SSL certificates
         // changeOrigin: true
+    },
+    "/erupt": {
+        target: 'http://localhost:9999',
+        secure: false,
+        changeOrigin: true,
+        ws: true,
     }
 };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,6 @@ import {LayoutModule} from './layout/layout.module';
 import {RoutesModule} from './routes/routes.module';
 import {SharedModule} from '@shared/shared.module';
 import {AppRoutingModule} from "./app-routing.module";
-import {I18nPipe} from "@shared/pipe/i18n.pipe";
 import {AppViewService} from "@shared/service/app-view.service";
 
 

--- a/src/app/build/erupt/model/erupt-api.model.ts
+++ b/src/app/build/erupt/model/erupt-api.model.ts
@@ -7,6 +7,14 @@ export interface EruptApiModel {
     promptWay: PromptWay;
 }
 
+export interface R<T> {
+    status: Status;
+    success: boolean;
+    message: string;
+    data: T;
+    promptWay: PromptWay;
+}
+
 export enum PromptWay {
     DIALOG = "DIALOG",
     MESSAGE = "MESSAGE",

--- a/src/app/build/erupt/model/erupt-tenant.ts
+++ b/src/app/build/erupt/model/erupt-tenant.ts
@@ -1,0 +1,22 @@
+export interface TenantDomainInfo {
+    code: string;
+    name: string;
+    logo: string;
+    js: string;
+    css: string;
+}
+
+
+let tenantDomainInfo: TenantDomainInfo = window["eruptTenantDomainInfo"] || null;
+
+export class EruptTenantInfoData {
+
+    static get() {
+        return tenantDomainInfo;
+    }
+
+    static put(value: TenantDomainInfo) {
+        tenantDomainInfo = value;
+    }
+
+}

--- a/src/app/build/erupt/model/erupt.enum.ts
+++ b/src/app/build/erupt/model/erupt.enum.ts
@@ -3,6 +3,7 @@ import {WindowModel} from "@shared/model/window.model";
 export class RestPath {
     public static erupt: string = WindowModel.domain + "erupt-api";
     public static eruptApp: string = RestPath.erupt + "/erupt-app";
+    public static domainInfo: string = RestPath.erupt + "/tenant/domain-info";
     public static tpl: string = RestPath.erupt + "/tpl";
     public static build: string = RestPath.erupt + "/build";
     public static data: string = RestPath.erupt + "/data";

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -106,6 +106,7 @@ export interface RowOperation {
     title: string;
     mode: OperationMode;
     type: OperationType;
+    fold: boolean;
     tip: string;
     callHint: string;
     ifExpr: string;

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -13,10 +13,9 @@
                     <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.rowOperation">
                         <ng-container *ngFor="let item of eruptBuildModel.eruptModel.eruptJson.rowOperation">
                             <ng-container *ngIf="item.mode != operationMode.SINGLE">
-                                <button nz-button nzType="dashed" class="mb-sm" [nz-tooltip]="item.tip"
-                                        (click)="createOperator(item)">
-                                    <i class="fa" [ngClass]="item.icon"></i>
-                                    <span style="margin-left: 8px;">{{ item.title }}</span>
+                                <button nz-button nzType="dashed" class="mb-sm" [nz-tooltip]="item.tip" (click)="createOperator(item)">
+                                    <i *ngIf="item.icon" class="fa" [ngClass]="item.icon" style="margin-right: 8px"></i>
+                                    <span>{{ item.title }}</span>
                                 </button>
                             </ng-container>
                         </ng-container>

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -406,38 +406,32 @@ export class TableComponent implements OnInit, OnDestroy {
                 return false;
             }
         }
+        let foldButtons = [];
         for (let i in this.eruptBuildModel.eruptModel.eruptJson.rowOperation) {
             let ro = this.eruptBuildModel.eruptModel.eruptJson.rowOperation[i];
             if (ro.mode !== OperationMode.BUTTON && ro.mode !== OperationMode.MULTI_ONLY) {
-                let text = "";
-                if (ro.icon) {
-                    text = `<i class=\"${ro.icon}\"></i>`;
+                if (ro.fold) {
+                    foldButtons.push(ro)
                 } else {
-                    text = ro.title;
-                }
-
-                tableButtons.push({
-                    type: 'link',
-                    text: text,
-                    tooltip: ro.title + (ro.tip && "(" + ro.tip + ")"),
-                    click: (record: any, modal: any) => {
-                        that.createOperator(ro, record);
-                    },
-                    iifBehavior: ro.ifExprBehavior == OperationIfExprBehavior.DISABLE ? "disabled" : "hide",
-                    iif: (item) => {
-                        return exprEval(ro.ifExpr, item);
+                    let text = "";
+                    if (ro.icon) {
+                        text = `<i class=\"${ro.icon}\"></i>`;
+                    } else {
+                        text = ro.title;
                     }
-                });
-                // editButtons.push({
-                //     label: ro.title,
-                //     type: 'dashed',
-                //     show: (options: ModalButtonOptions<any>) => {
-                //         return !ro.ifExpr;
-                //     },
-                //     onClick(options: ModalButtonOptions<any>) {
-                //         that.createOperator(ro, options);
-                //     }
-                // })
+                    tableButtons.push({
+                        type: 'link',
+                        text: text,
+                        tooltip: ro.title + (ro.tip && "(" + ro.tip + ")"),
+                        click: (record: any, modal: any) => {
+                            that.createOperator(ro, record);
+                        },
+                        iifBehavior: ro.ifExprBehavior == OperationIfExprBehavior.DISABLE ? "disabled" : "hide",
+                        iif: (item) => {
+                            return exprEval(ro.ifExpr, item);
+                        }
+                    });
+                }
             }
         }
 
@@ -588,11 +582,28 @@ export class TableComponent implements OnInit, OnDestroy {
             });
         }
         tableOperators.push(...tableButtons);
+        if (foldButtons.length > 0) {
+            let children: STColumnButton[] = [];
+            for (let btn of foldButtons) {
+                children.push({
+                    // icon: btn.icon && `<i class="${btn.icon}"></i>`,
+                    text: btn.title,
+                    iifBehavior: 'disabled',
+                    tooltip: btn.tooltip,
+                    iif: (item) => exprEval(btn.ifExpr, item),
+                    click: (record) => that.createOperator(btn, record)
+                })
+            }
+            tableOperators.push({
+                text: this.i18n.fanyi("global.more") + " ",
+                children: children
+            });
+        }
         if (tableOperators.length > 0) {
             _columns.push({
                 title: this.i18n.fanyi("table.operation"),
                 fixed: "right",
-                width: tableOperators.length * 35 + 18,
+                width: tableOperators.length * 35 + 18 + (foldButtons.length ? 60 : 0),
                 className: "text-center",
                 buttons: tableOperators,
                 resizable: false

--- a/src/app/build/tpl/tpl-routing.module.ts
+++ b/src/app/build/tpl/tpl-routing.module.ts
@@ -6,10 +6,6 @@ import {TplComponent} from "./tpl.component";
 const routes: Routes = [{
     path: "",
     component: TplComponent,
-    data: {
-        desc: "tpl",
-        status: true
-    }
 }];
 
 @NgModule({

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -13,6 +13,7 @@ import {I18NService} from "../i18n/i18n.service";
 import {R} from "../../build/erupt/model/erupt-api.model";
 import {EruptTenantInfoData, TenantDomainInfo} from "../../build/erupt/model/erupt-tenant";
 import {NzMessageService} from "ng-zorro-antd/message";
+import {SocketService} from "@shared/service/socket.service";
 
 
 @Injectable()
@@ -22,6 +23,7 @@ export class StartupService {
                 private titleService: TitleService,
                 private settingSrv: SettingsService,
                 private i18n: I18NService,
+                private socketService: SocketService,
                 @Inject(NzMessageService) private msg: NzMessageService,
                 @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService) {
         iconSrv.addIcon(...ICONS_AUTO);
@@ -58,7 +60,8 @@ export class StartupService {
                             window['SW'] = null;
                         }
                     }, 2000)
-                    EruptAppData.put(<EruptAppModel>JSON.parse(xhr.responseText));
+                    let eruptAppProp = <EruptAppModel>JSON.parse(xhr.responseText);
+                    EruptAppData.put(eruptAppProp);
                     if (!!EruptAppData.get().properties["erupt-tenant"]) {
                         let domainInfoXhr = new XMLHttpRequest();
                         domainInfoXhr.open('GET', RestPath.domainInfo + "?host=" + location.host);
@@ -83,6 +86,7 @@ export class StartupService {
                                         }
                                     }
                                     WindowModel.init();
+                                    EruptAppData.put(eruptAppProp);
                                 }
                                 resolve();
                             }
@@ -103,6 +107,9 @@ export class StartupService {
         };
         if (WindowModel.eruptEvent) {
             WindowModel.eruptEvent.startup && WindowModel.eruptEvent.startup();
+        }
+        if (!!EruptAppData.get().properties["erupt-websocket"]) {
+            this.socketService.initWebSocket();
         }
         //路由复用
         this.settingSrv.layout['reuse'] = !!this.settingSrv.layout['reuse'];

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -64,7 +64,7 @@ export class StartupService {
                         let domainInfoXhr = new XMLHttpRequest();
                         domainInfoXhr.open('GET', RestPath.domainInfo + "?host=" + location.host);
                         domainInfoXhr.send();
-                        domainInfoXhr.onreadystatechange = function () {
+                        domainInfoXhr.onreadystatechange = () => {
                             if (domainInfoXhr.readyState == 4 && domainInfoXhr.status == 200) {
                                 let tenantDomainInfo = (<R<TenantDomainInfo>>JSON.parse(domainInfoXhr.responseText)).data;
                                 if (tenantDomainInfo) {

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -14,10 +14,7 @@ import {R} from "../../build/erupt/model/erupt-api.model";
 import {EruptTenantInfoData, TenantDomainInfo} from "../../build/erupt/model/erupt-tenant";
 import {NzMessageService} from "ng-zorro-antd/message";
 
-/**
- * 用于应用启动时
- * 一般用来获取应用所需要的基础数据等
- */
+
 @Injectable()
 export class StartupService {
     constructor(iconSrv: NzIconService,
@@ -31,6 +28,7 @@ export class StartupService {
     }
 
     async load(): Promise<any> {
+        WindowModel.init();
         if (WindowModel.copyright) {
             console.group(WindowModel.title);
             console.log("%c" +
@@ -84,7 +82,7 @@ export class StartupService {
                                             that.msg.error("tenant js err: " + e)
                                         }
                                     }
-                                    Object.assign(WindowModel, WindowModel.config)
+                                    WindowModel.init();
                                 }
                                 resolve();
                             }

--- a/src/app/core/startup/startup.service.ts
+++ b/src/app/core/startup/startup.service.ts
@@ -13,7 +13,6 @@ import {I18NService} from "../i18n/i18n.service";
 import {R} from "../../build/erupt/model/erupt-api.model";
 import {EruptTenantInfoData, TenantDomainInfo} from "../../build/erupt/model/erupt-tenant";
 import {NzMessageService} from "ng-zorro-antd/message";
-import {SocketService} from "@shared/service/socket.service";
 
 
 @Injectable()
@@ -23,7 +22,6 @@ export class StartupService {
                 private titleService: TitleService,
                 private settingSrv: SettingsService,
                 private i18n: I18NService,
-                private socketService: SocketService,
                 @Inject(NzMessageService) private msg: NzMessageService,
                 @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService) {
         iconSrv.addIcon(...ICONS_AUTO);
@@ -107,9 +105,6 @@ export class StartupService {
         };
         if (WindowModel.eruptEvent) {
             WindowModel.eruptEvent.startup && WindowModel.eruptEvent.startup();
-        }
-        if (!!EruptAppData.get().properties["erupt-websocket"]) {
-            this.socketService.initWebSocket();
         }
         //路由复用
         this.settingSrv.layout['reuse'] = !!this.settingSrv.layout['reuse'];

--- a/src/app/layout/erupt/erupt.component.ts
+++ b/src/app/layout/erupt/erupt.component.ts
@@ -46,6 +46,7 @@ import {EruptAppData} from "@shared/model/erupt-app.model";
 import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
 import {Userinfo} from "@shared/model/user.model";
 import {UtilsService} from "@shared/service/utils.service";
+import {SocketService} from "@shared/service/socket.service";
 
 // #region icons
 
@@ -110,6 +111,7 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
                 private settingsService: SettingsService,
                 @Inject(NzModalService)
                 private modal: NzModalService,
+                private socketService: SocketService,
                 @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService,
                 private i18n: I18NService,
                 private utilsService: UtilsService,
@@ -182,6 +184,9 @@ export class LayoutEruptComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     ngOnInit() {
+        if (!!EruptAppData.get().properties["erupt-websocket"]) {
+            this.socketService.initWebSocket();
+        }
         this.notify$ = this.settings.notify.subscribe(() => this.setClass());
         this.setClass();
         this.data.getMenu().subscribe(res => {

--- a/src/app/layout/erupt/header/components/user.component.ts
+++ b/src/app/layout/erupt/header/components/user.component.ts
@@ -9,6 +9,7 @@ import {NzModalService} from "ng-zorro-antd/modal";
 import {ResetPwdComponent} from "../../../../routes/reset-pwd/reset-pwd.component";
 import {EruptAppData} from "@shared/model/erupt-app.model";
 import {UtilsService} from "@shared/service/utils.service";
+import {SocketService} from "@shared/service/socket.service";
 
 @Component({
     selector: "header-user",
@@ -46,7 +47,8 @@ export class HeaderUserComponent {
         private dataService: DataService,
         @Inject(NzModalService)
         private modal: NzModalService,
-        private utilsService: UtilsService
+        private utilsService: UtilsService,
+        private socketService: SocketService,
     ) {
     }
 
@@ -55,6 +57,7 @@ export class HeaderUserComponent {
             nzTitle: this.i18n.fanyi("global.confirm_logout"),
             nzOnOk: () => {
                 this.dataService.logout().subscribe(data => {
+                    this.socketService.closeSocket();
                     let token = this.tokenService.get().token;
                     if (WindowModel.eruptEvent && WindowModel.eruptEvent.logout) {
                         WindowModel.eruptEvent.logout({
@@ -67,6 +70,7 @@ export class HeaderUserComponent {
                     } else {
                         this.router.navigateByUrl(this.tokenService.login_url);
                     }
+                    this.tokenService.clear();
                 });
             }
         });

--- a/src/app/layout/erupt/header/header.component.ts
+++ b/src/app/layout/erupt/header/header.component.ts
@@ -8,6 +8,8 @@ import {HeaderSearchComponent} from "./components/search.component";
 import {MenuVo} from "@shared/model/erupt-menu";
 import {AppViewService} from "@shared/service/app-view.service";
 import {EruptAppData} from "@shared/model/erupt-app.model";
+import {EruptTenantInfoData} from "../../../build/erupt/model/erupt-tenant";
+import {DataService} from "@shared/service/data.service";
 
 @Component({
     selector: "layout-header",
@@ -26,8 +28,6 @@ export class HeaderComponent implements OnInit {
 
     collapse: boolean = false;
 
-    title = WindowModel.title;
-
     logoPath: string = WindowModel.logoPath;
 
     logoText: string = WindowModel.logoText;
@@ -39,6 +39,8 @@ export class HeaderComponent implements OnInit {
     desc: string;
 
     showI18n: boolean = true;
+
+    tenantDomainInfo = EruptTenantInfoData.get();
 
     openDrawer() {
         this.drawerVisible = true;
@@ -52,6 +54,11 @@ export class HeaderComponent implements OnInit {
                 private router: Router,
                 private appViewService: AppViewService,
                 @Inject(NzModalService) private modal: NzModalService) {
+        if (this.tenantDomainInfo) {
+            if (this.tenantDomainInfo.logo) {
+                this.logoPath = DataService.previewAttachment(this.tenantDomainInfo.logo)
+            }
+        }
     }
 
     ngOnInit() {

--- a/src/app/layout/passport/login/login.component.ts
+++ b/src/app/layout/passport/login/login.component.ts
@@ -12,6 +12,7 @@ import {NzMessageService} from "ng-zorro-antd/message";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {ReuseTabService} from "@delon/abc/reuse-tab";
 import {EruptAppData} from "@shared/model/erupt-app.model";
+import {EruptTenantInfoData} from "../../../build/erupt/model/erupt-tenant";
 
 @Component({
     selector: "passport-login",
@@ -43,6 +44,8 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
 
     tenantLogin: boolean;
 
+    tenantDomainInfo = EruptTenantInfoData.get();
+
     constructor(
         fb: FormBuilder,
         private data: DataService,
@@ -65,7 +68,9 @@ export class UserLoginComponent implements OnDestroy, OnInit, AfterViewInit {
             mobile: [null, [Validators.required, Validators.pattern(/^1\d{10}$/)]],
             remember: [true]
         });
-
+        if (this.tenantDomainInfo) {
+            this.router.navigateByUrl('/passport/tenant').then(r => true)
+        }
     }
 
     ngOnInit(): void {

--- a/src/app/layout/passport/passport.component.ts
+++ b/src/app/layout/passport/passport.component.ts
@@ -1,6 +1,8 @@
 import {AfterViewInit, Component} from "@angular/core";
 import {WindowModel} from "@shared/model/window.model";
 import {NzModalService} from "ng-zorro-antd/modal";
+import {EruptTenantInfoData} from "../../build/erupt/model/erupt-tenant";
+import {DataService} from "@shared/service/data.service";
 
 @Component({
     selector: "layout-passport",
@@ -21,12 +23,19 @@ export class LayoutPassportComponent implements AfterViewInit {
 
     copyrightTxt = WindowModel.copyrightTxt;
 
+    tenantDomainInfo = EruptTenantInfoData.get();
+
     constructor(private modalSrv: NzModalService) {
         if (WindowModel.copyrightTxt) {
             if (typeof (WindowModel.copyrightTxt) === 'function') {
                 this.copyrightTxt = WindowModel.copyrightTxt();
             } else {
                 this.copyrightTxt = WindowModel.copyrightTxt;
+            }
+        }
+        if (this.tenantDomainInfo) {
+            if (this.tenantDomainInfo.logo) {
+                this.logoPath = DataService.previewAttachment(this.tenantDomainInfo.logo)
             }
         }
     }

--- a/src/app/layout/passport/tenant-login/tenant-login.component.html
+++ b/src/app/layout/passport/tenant-login/tenant-login.component.html
@@ -1,7 +1,7 @@
-<h3 style="margin-bottom: 26px;text-align: center">{{ '租户登录'|translate }}</h3>
+<h3 style="margin-bottom: 26px;text-align: center">{{ (tenantDomainInfo ? 'login.account_pwd_login' : '租户登录')|translate }}</h3>
 <form nz-form [formGroup]="form" (ngSubmit)="submit()" role="form">
     <nz-alert *ngIf="error" [nzType]="'error'" [nzMessage]="error" [nzShowIcon]="true" class="mb-lg"></nz-alert>
-    <nz-form-item>
+    <nz-form-item [hidden]="tenantDomainInfo">
         <nz-form-control>
             <nz-input-group nzSize="large" nzPrefixIcon="apartment">
                 <input nz-input formControlName="tenantCode" [placeholder]="'企业ID'">
@@ -67,7 +67,7 @@
                 style="display:block;width: 100%;">{{ 'login.button'|translate }}
         </button>
     </nz-form-item>
-    <p style="text-align: center;margin-top: 16px;">
+    <p style="text-align: center;margin-top: 16px;" *ngIf="!tenantDomainInfo">
         <a *ngIf="tenantLogin" (click)="toLogin()">{{ '平台登录' }}</a>
     </p>
 </form>

--- a/src/app/layout/passport/tenant-login/tenant-login.component.ts
+++ b/src/app/layout/passport/tenant-login/tenant-login.component.ts
@@ -11,6 +11,7 @@ import {I18NService} from "@core";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {ReuseTabService} from "@delon/abc/reuse-tab";
 import {EruptAppData} from "@shared/model/erupt-app.model";
+import {EruptTenantInfoData} from "../../../build/erupt/model/erupt-tenant";
 
 @Component({
     selector: "passport-login",
@@ -40,6 +41,8 @@ export class UserTenantLoginComponent implements OnDestroy, OnInit, AfterViewIni
 
     tenantLogin: boolean;
 
+    tenantDomainInfo = EruptTenantInfoData.get();
+
     constructor(
         fb: FormBuilder,
         private data: DataService,
@@ -61,7 +64,9 @@ export class UserTenantLoginComponent implements OnDestroy, OnInit, AfterViewIni
             mobile: [null, [Validators.required, Validators.pattern(/^1\d{10}$/)]],
             remember: [true]
         });
-
+        if (this.tenantDomainInfo) {
+            this.tenantCode.setValue(this.tenantDomainInfo.code);
+        }
     }
 
     ngOnInit(): void {

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -13,6 +13,8 @@ import {SiteComponent} from "./site/site.component";
 import {LayoutEruptComponent} from "../layout/erupt/erupt.component";
 import {UserTenantLoginComponent} from "../layout/passport/tenant-login/tenant-login.component";
 
+let tplLoad = import( "../build/tpl/tpl.module");
+
 // layout
 let coreRouter: Routes = [
     {path: "", component: HomeComponent, data: {title: "首页"}},
@@ -33,19 +35,24 @@ let coreRouter: Routes = [
         loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)
     },
     {
-        path: 'tpl/:name/:name1',
+        path: 'tpl/:name/:name2',
         pathMatch: "full",
-        loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)
+        loadChildren: () => tplLoad.then(m => m.TplModule)
     },
     {
         path: 'tpl/:name/:name2/:name3',
         pathMatch: "full",
-        loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)
+        loadChildren: () => tplLoad.then(m => m.TplModule)
     },
     {
         path: 'tpl/:name/:name2/:name3/:name4',
         pathMatch: "full",
-        loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+    {
+        path: 'tpl/:name/:name2/:name3/:name4/:name5',
+        pathMatch: "full",
+        loadChildren: () => tplLoad.then(m => m.TplModule)
     }
 ];
 

--- a/src/app/shared/model/window.model.ts
+++ b/src/app/shared/model/window.model.ts
@@ -6,29 +6,44 @@ export class WindowModel {
 
     public static fileDomain: string = WindowModel.config["fileDomain"] || undefined;
 
-    public static r_tools: CustomerTool[] = WindowModel.config["r_tools"] || [];
+    public static r_tools: CustomerTool[];
 
-    public static amapKey: string = WindowModel.config["amapKey"];
+    public static amapKey: string;
 
-    public static amapSecurityJsCode: string = WindowModel.config["amapSecurityJsCode"];
+    public static amapSecurityJsCode: string;
 
-    public static title: string = WindowModel.config["title"] || 'Erupt Framework';
+    public static title: string;
 
-    public static desc: string = WindowModel.config["desc"] || undefined;
+    public static desc: string;
 
-    public static logoPath: string = WindowModel.config["logoPath"] === '' ? null : (WindowModel.config["logoPath"] || "erupt.svg");
+    public static logoPath: string;
 
-    public static loginLogoPath: string = WindowModel.config["loginLogoPath"] === '' ? null : (WindowModel.config["loginLogoPath"] || WindowModel.logoPath);
+    public static loginLogoPath: string;
 
-    public static logoText: string = WindowModel.config["logoText"] || "";
+    public static logoText: string;
 
-    public static registerPage: string = WindowModel.config["registerPage"] || undefined; //注册页面地址
+    public static registerPage: string; //注册页面地址
 
-    public static copyright: boolean = WindowModel.config["copyright"];
+    public static copyright: boolean;
 
-    public static copyrightTxt: any = WindowModel.config["copyrightTxt"]; //授权文本
+    public static copyrightTxt: any; //授权文本
 
-    public static upload: Function = WindowModel.config["upload"] || false;
+    public static upload: Function;
+
+    public static init() {
+        WindowModel.r_tools = WindowModel.config["r_tools"] || [];
+        WindowModel.amapKey = WindowModel.config["amapKey"];
+        WindowModel.amapSecurityJsCode = WindowModel.config["amapSecurityJsCode"];
+        WindowModel.title = WindowModel.config["title"] || 'Erupt Framework';
+        WindowModel.desc = WindowModel.config["desc"] || undefined;
+        WindowModel.logoPath = WindowModel.config["logoPath"] === '' ? null : (WindowModel.config["logoPath"] || "erupt.svg");
+        WindowModel.loginLogoPath = WindowModel.config["loginLogoPath"] === '' ? null : (WindowModel.config["loginLogoPath"] || WindowModel.logoPath);
+        WindowModel.logoText = WindowModel.config["logoText"] || "";
+        WindowModel.registerPage = WindowModel.config["registerPage"] || undefined; //注册页面地址
+        WindowModel.copyright = WindowModel.config["copyright"];
+        WindowModel.copyrightTxt = WindowModel.config["copyrightTxt"]; //授权文本
+        WindowModel.upload = WindowModel.config["upload"] || false;
+    }
 
     public static eruptEvent: {
         login?: Function,

--- a/src/app/shared/model/window.model.ts
+++ b/src/app/shared/model/window.model.ts
@@ -1,6 +1,6 @@
 export class WindowModel {
 
-    private static config: any = window["eruptSiteConfig"] || {};
+    public static config: any = window["eruptSiteConfig"] || {};
 
     public static domain: string = WindowModel.config["domain"] ? WindowModel.config["domain"] + "/" : '';
 

--- a/src/app/shared/service/socket.service.ts
+++ b/src/app/shared/service/socket.service.ts
@@ -1,0 +1,97 @@
+import {Inject, Injectable} from "@angular/core";
+import {WindowModel} from "@shared/model/window.model";
+import {NzMessageService} from "ng-zorro-antd/message";
+import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
+
+@Injectable()
+export class SocketService {
+
+    private socket: WebSocket;
+
+    private heartBeatTimer: any;
+
+    // 重连间隔时间（毫秒）
+    private reconnectInterval: number = 5000;
+
+    // 重连次数
+    private reconnectAttempts: number = 0;
+
+    constructor(
+        @Inject(NzMessageService) private msg: NzMessageService,
+        @Inject(DA_SERVICE_TOKEN) private tokenService: ITokenService) {
+    }
+
+    public initWebSocket(): void {
+        this.reconnectAttempts = 0;
+        let websocketUrl: string;
+        if (WindowModel.domain) {
+            websocketUrl = (WindowModel.domain.startsWith('http:') ? 'ws:' : 'wss:') + location.host.split(":")[1];
+        } else {
+            websocketUrl = (location.protocol === 'http:' ? 'ws:' : 'wss:') + "//" + location.host;
+        }
+        this.socket = new WebSocket(websocketUrl + '/erupt?token=' + this.tokenService.get().token);
+
+        this.socket.onopen = () => {
+            // 启动心跳
+            this.startHeartbeat();
+        };
+
+        this.socket.onmessage = (event) => {
+            let data = event.data as string[];
+            if (data?.[0] == "js") {
+                try {
+                    eval(data[1])
+                } catch (e) {
+                    this.msg.warning("socket js err: " + e);
+                }
+            }
+            // TODO broadcast
+        };
+
+        this.socket.onerror = (event) => {
+            console.error("socket error", event)
+        };
+
+        this.socket.onclose = (event) => {
+            console.log("WebSocket连接已关闭，关闭原因：", event.code, event.reason);
+            setTimeout(reconnect, this.reconnectInterval);
+        };
+
+        let reconnect = () => {
+            this.reconnectAttempts++;
+            this.clearHeartbeatTimer();
+            console.log("正在进行第", this.reconnectAttempts, "次 websocket 重连尝试...");
+            this.socket.close();
+            this.initWebSocket();
+        }
+
+    }
+
+    clearHeartbeatTimer() {
+        if (this.heartBeatTimer) {
+            clearInterval(this.heartBeatTimer);
+            this.heartBeatTimer = null;
+        }
+    }
+
+    startHeartbeat() {
+        this.clearHeartbeatTimer();
+        // 设置心跳定时器，每隔HEARTBEAT_INTERVAL毫秒发送一次心跳
+        this.heartBeatTimer = setInterval(() => {
+            if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+                this.socket.send(JSON.stringify(["PING"]));
+            } else {
+                console.log("WebSocket未连接，无法发送心跳消息。");
+            }
+        }, 5000);
+    }
+
+    sendMessage(command: string,data: any) {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify([command, data]));
+        } else {
+            console.log("WebSocket未连接，无法发送消息。", data);
+        }
+    }
+
+}

--- a/src/app/shared/service/socket.service.ts
+++ b/src/app/shared/service/socket.service.ts
@@ -54,6 +54,7 @@ export class SocketService {
 
         this.socket.onclose = (event) => {
             console.log("WebSocket连接已关闭，关闭原因：", event.code, event.reason);
+            //1002 token error
             if (event.code != 1002) {
                 setTimeout(reconnect, this.reconnectInterval);
             }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -23,6 +23,7 @@ import {STWidgetRegistry} from "@delon/abc/st";
 import {UEditorComponent} from "@shared/component/ueditor/ueditor.component";
 import {EruptContextService} from "@shared/service/erupt-context.service";
 import {UtilsService} from "@shared/service/utils.service";
+import {SocketService} from "@shared/service/socket.service";
 
 // #region third libs
 // import { NgxTinymceModule } from 'ngx-tinymce';
@@ -59,7 +60,8 @@ const DIRECTIVES: Array<Type<any>> = [RipperDirective, SafeHtmlPipe, SafeScriptP
         DataService,
         UtilsService,
         EruptContextService,
-        EruptStorageService
+        EruptStorageService,
+        SocketService
     ],
     exports: [
         CommonModule,

--- a/src/erupt.i18n.csv
+++ b/src/erupt.i18n.csv
@@ -36,6 +36,7 @@ global.update.loading.hint,数据加载中无法保存!,數據加載中無法保
 global.no_data,暂无数据,無此資料,No Data,Aucune donnée,データがありません,데이터 없음,Приходящее множество доказательств,Datos aún no disponibles
 global.copy_success,复制成功,復製成功,Successful replication,Copiez avec succès,複製成功です,복사에 성공했습니다,Подтверждаю.,Replicar el éxito
 global.pre_select,请先选择,請先選擇,Please select first,Veuillez sélectionner d’abord,先にお願いします,먼저 선택하세요,Выбирайте.,Por favor seleccione primero
+global.more,更多,更多,more,plus,もっと,더,больше,di più.
 component.attachment.upload_hint,单击或拖动文件到此区域上传,單擊或拖動文件到此區域上傳,Click or drag the file to this area to upload,Cliquez ou faites glisser les fichiers dans cette zone pour les télécharger,ファイルをクリックまたはドラッグしてアップロードします,파일을이 영역으로 업로드하려면 누르거나 드래그하십시오,Нажмите или перетащите файл в эту область,Haga clic o arrastre los archivos a esta área para subir
 component.attachment.upload_format,文件格式,文件格式,File format,Format du fichier,ファイル形式です。,파일 형식,Формат файла,Formato de archivo
 table.operation,操作,操作,Operation,opérations,操作,조작,операцион,La operación

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -18,3 +18,9 @@ body.color-gray{
     transition: filter 0.5s;
     background: #fff;
 }
+
+
+* {
+    scrollbar-width: thin;
+    scrollbar-color: #888888 #f1f1f1;
+}

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -20,6 +20,24 @@ body.color-gray{
 }
 
 
+
+
+/* 滚动条轨道样式 */
+::-webkit-scrollbar-track {
+    background: #f1f1f1; /* 轨道颜色 */
+}
+
+/* 滚动条滑块样式 */
+::-webkit-scrollbar-thumb {
+    background-color: #888888; /* 滑块颜色 */
+    border-radius: 4px; /* 滑块圆角 */
+}
+
+/* 滑块悬停时的样式 */
+::-webkit-scrollbar-thumb:hover {
+    background-color: #767676; /* 滑块悬停时颜色 */
+}
+
 * {
     scrollbar-width: thin;
     scrollbar-color: #888888 #f1f1f1;


### PR DESCRIPTION
🐞 解决commons-io版本冲突导致excel导入功能异常的bug
🐞 解决gson number序列化结果被科学计数法与Integer类型上传内容带.0的问题
🧩 优化excel导入，解决如果修饰类型为string，单元格类型为数值则结果带.0的问题
🧩 优化window浏览器滚动条样式，统一使用mac风格
🌟 新增erupt-cloud-server docker镜像，可通过docker的方式快速部署分布式server端 [#284](https://github.com/erupts/erupt/pull/284)
感谢 [Barcke](https://github.com/Barcke) 贡献的代码
🌟 自定义按钮支持折叠配置 [fold](https://www.yuque.com/erupts/erupt/gaing7)，可将自定义按钮折叠展示, 适用于按钮过多的场景
🌟 erupt 支持增、删、改事件传递，监听erupt系统类与第三方类的变化，用于解耦 
🌟 Excel 导入能力支持按需导入，自由定义导入时插入或更新等操作 
🌟 @erupt 注解支持[自定义UI注解](https://www.yuque.com/erupts/erupt/rxq42y50yqb3427x)，可以将其他类注解的信息传递给前端，用于自定义解析，扩展注解边界
🌟 开源 [erupt-websocket](https://www.yuque.com/erupts/erupt/vidv3vg1l3gl5z8s) 模块，可在任何地方执行前端JS脚本，用于错误提示，异步结果通知等频繁交互场景
🌟 erupt-tenant 兼容 erupt-bi 可开发租户报表
🌟 erupt-tenant 支持域名控制，通过域名控制网页标题，图标，国际化语言，水印等信息