### PR TITLE
【修复】REFERENCE_TABLE多对一引组件作为查询条件时，联动失效问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
         "screenfull": "^6.0.2",
         "ts-md5": "^1.3.1",
         "tslib": "^2.3.0",
-        "zone.js": "~0.11.4"
+        "zone.js": "~0.11.4",
+        "lodash": "~4.17.21"
     },
     "devDependencies": {
         "@angular-devkit/build-angular": "^15.2.0",

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -6,6 +6,7 @@ import {SettingsService} from "@delon/theme";
 import {EditTypeComponent} from "../../components/edit-type/edit-type.component";
 import {EditComponent} from "../edit/edit.component";
 import {EruptBuildModel} from "../../model/erupt-build.model";
+import  {cloneDeep}  from "lodash";
 import {
     FormSize,
     OperationIfExprBehavior,
@@ -28,7 +29,6 @@ import {NzMessageService} from "ng-zorro-antd/message";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {STColumn, STColumnButton, STComponent} from "@delon/abc/st";
 import {NzModalRef} from "ng-zorro-antd/modal/modal-ref";
-import {deepCopy} from "@delon/util";
 import {ModalButtonOptions} from "ng-zorro-antd/modal/modal-types";
 import {STChange, STPage} from "@delon/abc/st/st.interfaces";
 import {AppViewService} from "@shared/service/app-view.service";
@@ -257,7 +257,7 @@ export class TableComponent implements OnInit, OnDestroy {
                 callback && callback(eb);
                 this.eruptBuildModel = eb;
                 this.buildTableConfig();
-                this.searchErupt = <EruptModel>deepCopy(this.eruptBuildModel.eruptModel);
+                this.searchErupt = <EruptModel>cloneDeep(this.eruptBuildModel.eruptModel);
                 for (let fieldModel of this.searchErupt.eruptFieldModels) {
                     let edit = fieldModel.eruptFieldJson.edit;
                     if (edit) {


### PR DESCRIPTION
#### 说明

【修复】REFERENCE_TABLE多对一引组件作为查询条件时，联动效问题

1.问题描述：问题复现在1.12.17版本中，使用中发现在作为查询条件时，多对一组件无法获取dependField字段值，如下图
![image](https://github.com/user-attachments/assets/254f7655-4a0b-4da9-a358-fdfefa91ef15)

2.问题定位：经debug发现，系前端@delon/util包下的deepCopy方法存在问题，深复制后的searchErupt、eruptModel的eruptFieldModelMap属性指向同一对象，导致多对一组件读取不到dependField对应的值
![1736824820817](https://github.com/user-attachments/assets/bc5fc97a-8308-4004-a839-aa687c0e2f69)
3.解决方法：引入lodash包，改用cloneDeep方法进行深复制，经debug，改用cloneDeep深复制的searchErupt与eruptModel的eruptFieldModelMap属性不再指向同一对象
![1736825164231](https://github.com/user-attachments/assets/0f5f20d6-e59f-4bd8-a7a1-e3967fe7fb58)

