### PR TITLE
1.12.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@delon/form": "^15.2.1",
         "@delon/theme": "^15.2.1",
         "@delon/util": "^15.2.1",
+        "@micro-zoe/micro-app": "^1.0.0-rc.19",
         "@ng-util/lazy": "^14.0.0",
         "@ng-util/util": "^14.0.0",
         "font-awesome": "^4.7.0",

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -4,7 +4,9 @@
             <ng-container *ngIf="ready && data && data.length">
                 <nz-alert nzType="info" [nzMessage]="alertMessage" style="margin-bottom: 12px"></nz-alert>
                 <ng-template #alertMessage>
-                    <span [innerHTML]="data.length && data[0]?.x | safeHtml"></span>
+                    <ng-container *ngFor="let d of data">
+                        <p [innerHTML]="d.x | safeHtml" style="margin-bottom: 0"></p>
+                    </ng-container>
                 </ng-template>
             </ng-container>
         </ng-container>
@@ -22,7 +24,8 @@
                         <ng-container [ngSwitch]="chart.type">
                             <ng-container *ngSwitchCase="chartType.tpl">
                                 <ng-container *ngIf="!src">
-                                    <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center"
+                                    <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null"
+                                              class="flex-center-center"
                                               [style]="{height:chart.height+'px'}">
 
                                     </nz-empty>
@@ -87,7 +90,8 @@
                 </ng-container>
                 <ng-container *ngIf="bi.export && data && data.length>0">
                     <i nz-icon [nzType]="'loading'" *ngIf="downloading"></i>
-                    <i nz-icon nzType="download" *ngIf="!downloading" nzTheme="outline" (click)="downloadChartData()"></i>
+                    <i nz-icon nzType="download" *ngIf="!downloading" nzTheme="outline"
+                       (click)="downloadChartData()"></i>
                     &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
                 </ng-container>
                 <i nz-icon nzType="reload" (click)="update(true)"></i>

--- a/src/app/build/bi/chart/chart.component.html
+++ b/src/app/build/bi/chart/chart.component.html
@@ -1,84 +1,100 @@
 <nz-spin [nzSpinning]="chart.loading">
-    <nz-card [nzTitle]="chart.name" nzSize="small" [nzBodyStyle]="{padding:'0'}" [nzHoverable]="true"
-             [nzExtra]="extraTemplate" style="margin-bottom: 12px">
-        <div [ngClass]="open?'card-show':'card-hide'">
-            <ng-container *ngIf="!ready">
-                <div [id]='chart.code' [ngStyle]="{height:chart.height+'px'}"
-                     style='width:100%;display: flex;flex-direction: column;align-items:center;justify-content: center;'>
-                    <i nz-icon nzType="pie-chart" nzTheme="twotone" style="font-size: 36px"></i>
-                </div>
+    <ng-container [ngSwitch]="chart.type">
+        <ng-container *ngSwitchCase="chartType.Alert">
+            <ng-container *ngIf="ready && data && data.length">
+                <nz-alert nzType="info" [nzMessage]="alertMessage" style="margin-bottom: 12px"></nz-alert>
+                <ng-template #alertMessage>
+                    <span [innerHTML]="data.length && data[0]?.x | safeHtml"></span>
+                </ng-template>
             </ng-container>
-            <ng-container *ngIf="ready">
-                <ng-container [ngSwitch]="chart.type">
-                    <ng-container *ngSwitchCase="chartType.tpl">
-                        <ng-container *ngIf="!src">
-                            <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center" [style]="{height:chart.height+'px'}">
-
-                            </nz-empty>
-                        </ng-container>
-                        <ng-container *ngIf="src">
-                            <erupt-iframe [url]="src" [style]="{height:chart.height+'px',paddingTop:'1px'}">
-
-                            </erupt-iframe>
-                        </ng-container>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="chartType.table">
-                        <div [ngStyle]="{height:chart.height+'px'}" style="overflow: auto">
-                            <erupt-chart-table #chartTable [id]="chart.code"></erupt-chart-table>
+        </ng-container>
+        <ng-container *ngSwitchDefault>
+            <nz-card [nzTitle]="chart.name" nzSize="small" [nzBodyStyle]="{padding:'0'}" [nzHoverable]="true"
+                     [nzExtra]="extraTemplate" style="margin-bottom: 12px">
+                <div [ngClass]="open?'card-show':'card-hide'">
+                    <ng-container *ngIf="!ready">
+                        <div [id]='chart.code' [ngStyle]="{height:chart.height+'px'}"
+                             style='width:100%;display: flex;flex-direction: column;align-items:center;justify-content: center;'>
+                            <i nz-icon nzType="pie-chart" nzTheme="twotone" style="font-size: 36px"></i>
                         </div>
                     </ng-container>
-                    <ng-container *ngSwitchCase="chartType.Number">
-                        <ng-container *ngIf="!data||data.length==0">
-                            <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center">
+                    <ng-container *ngIf="ready">
+                        <ng-container [ngSwitch]="chart.type">
+                            <ng-container *ngSwitchCase="chartType.tpl">
+                                <ng-container *ngIf="!src">
+                                    <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center"
+                                              [style]="{height:chart.height+'px'}">
 
-                            </nz-empty>
-                        </ng-container>
-                        <ng-container *ngIf="data&&data.length">
-                            <div style="padding: 12px;text-align: center;" [id]="chart.code">
-                                <div sg-container="{{data.length}}">
-                                    <ng-container *ngFor="let d of data">
-                                        <sg>
-                                            <nz-statistic style="margin-bottom: 16px;"
-                                                          [nzValue]="d[dataKeys[0]]||0"
-                                                          [nzTitle]="d[dataKeys[1]]"
-                                                          [nzValueStyle]="this.chart.chartOption"
-                                            ></nz-statistic>
-                                        </sg>
+                                    </nz-empty>
+                                </ng-container>
+                                <ng-container *ngIf="src">
+                                    <erupt-iframe [url]="src" [style]="{height:chart.height+'px',paddingTop:'1px'}">
+
+                                    </erupt-iframe>
+                                </ng-container>
+                            </ng-container>
+                            <ng-container *ngSwitchCase="chartType.table">
+                                <div [ngStyle]="{height:chart.height+'px'}" style="overflow: auto">
+                                    <erupt-chart-table #chartTable [id]="chart.code"></erupt-chart-table>
+                                </div>
+                            </ng-container>
+                            <ng-container *ngSwitchCase="chartType.Number">
+                                <ng-container *ngIf="!data||data.length==0">
+                                    <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null"
+                                              class="flex-center-center">
+
+                                    </nz-empty>
+                                </ng-container>
+                                <ng-container *ngIf="data&&data.length">
+                                    <div style="padding: 12px;text-align: center;" [id]="chart.code">
+                                        <div sg-container="{{data.length}}">
+                                            <ng-container *ngFor="let d of data">
+                                                <sg>
+                                                    <nz-statistic style="margin-bottom: 16px;"
+                                                                  [nzValue]="d[dataKeys[0]]||0"
+                                                                  [nzTitle]="d[dataKeys[1]]"
+                                                                  [nzValueStyle]="this.chart.chartOption"
+                                                    ></nz-statistic>
+                                                </sg>
+                                            </ng-container>
+                                        </div>
+                                    </div>
+                                </ng-container>
+                            </ng-container>
+                            <ng-container *ngSwitchDefault>
+                                <div [id]='chart.code' style='width:100%;' [ngStyle]="{height:chart.height+'px'}">
+                                    <ng-container *ngIf="!data||data.length==0">
+                                        <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null"
+                                                  class="flex-center-center">
+
+                                        </nz-empty>
                                     </ng-container>
                                 </div>
-                            </div>
+                            </ng-container>
                         </ng-container>
                     </ng-container>
-                    <ng-container *ngSwitchDefault>
-                        <div [id]='chart.code' style='width:100%;' [ngStyle]="{height:chart.height+'px'}">
-                            <ng-container *ngIf="!data||data.length==0">
-                                <nz-empty nzNotFoundImage="simple" [nzNotFoundContent]="null" class="flex-center-center">
-
-                                </nz-empty>
-                            </ng-container>
-                        </div>
-                    </ng-container>
+                </div>
+            </nz-card>
+            <ng-template #extraTemplate>
+                <ng-container *ngIf="chart.remark">
+                <span nz-icon nzType="question-circle" nzTheme="outline" nz-tooltip
+                      [nzTooltipTitle]="chart.remark"></span>
+                    &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
                 </ng-container>
-            </ng-container>
-        </div>
-    </nz-card>
-    <ng-template #extraTemplate>
-        <ng-container *ngIf="chart.remark">
-            <span nz-icon nzType="question-circle" nzTheme="outline" nz-tooltip [nzTooltipTitle]="chart.remark"></span>
-            &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
+                <ng-container *ngIf="plot">
+                    <i nz-icon nzType="file-image" nzTheme="outline" (click)="downloadChartImage()"></i>
+                    &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
+                </ng-container>
+                <ng-container *ngIf="bi.export && data && data.length>0">
+                    <i nz-icon [nzType]="'loading'" *ngIf="downloading"></i>
+                    <i nz-icon nzType="download" *ngIf="!downloading" nzTheme="outline" (click)="downloadChartData()"></i>
+                    &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
+                </ng-container>
+                <i nz-icon nzType="reload" (click)="update(true)"></i>
+                &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
+                <span nz-icon nzType="down" nzTheme="outline" *ngIf="open" (click)="open=false"></span>
+                <span nz-icon nzType="left" nzTheme="outline" *ngIf="!open" (click)="open=true"></span>
+            </ng-template>
         </ng-container>
-        <ng-container *ngIf="plot">
-            <i nz-icon nzType="file-image" nzTheme="outline" (click)="downloadChartImage()"></i>
-            &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
-        </ng-container>
-        <ng-container *ngIf="bi.export && data && data.length>0">
-            <i nz-icon [nzType]="'loading'" *ngIf="downloading"></i>
-            <i nz-icon nzType="download" *ngIf="!downloading" nzTheme="outline" (click)="downloadChartData()"></i>
-            &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
-        </ng-container>
-        <i nz-icon nzType="reload" (click)="update(true)"></i>
-        &nbsp;<nz-divider nzType="vertical"></nz-divider>&nbsp;
-        <span nz-icon nzType="down" nzTheme="outline" *ngIf="open" (click)="open=false"></span>
-        <span nz-icon nzType="left" nzTheme="outline" *ngIf="!open" (click)="open=true"></span>
-    </ng-template>
+    </ng-container>
 </nz-spin>

--- a/src/app/build/bi/model/bi.model.ts
+++ b/src/app/build/bi/model/bi.model.ts
@@ -37,6 +37,7 @@ export interface ChartColumn {
 }
 
 export enum ChartType {
+    Alert = "Alert",
     Number = "Number",
     Line = "Line",
     StepLine = "StepLine",

--- a/src/app/build/bi/skeleton/skeleton.component.html
+++ b/src/app/build/bi/skeleton/skeleton.component.html
@@ -2,7 +2,7 @@
     <nz-skeleton [nzActive]="true" [nzTitle]="true" [nzParagraph]="{ rows: 10 }" *ngIf="!bi"></nz-skeleton>
     <div [id]="name">
         <ng-container *ngIf="bi">
-            <div style="display: flex">
+            <div style="display: flex;margin-bottom: 4px">
                 <ng-container>
                     <button nz-button class="mb-sm" [nzLoading]="querying" (click)="query({
                             pageIndex: 1,
@@ -48,7 +48,7 @@
                 </div>
             </div>
 
-            <nz-card *ngIf="bi.dimensions.length>0" [nzHoverable]="true" style="margin-bottom: 12px;margin-top: 4px"
+            <nz-card *ngIf="bi.dimensions.length>0" [nzHoverable]="true" style="margin-bottom: 12px"
                      [hidden]="hideCondition" nzSize="small">
                 <bi-dimension [bi]="bi" (search)="query({
                             pageIndex: 1,

--- a/src/app/build/erupt/components/edit-type/edit-type.component.html
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.html
@@ -207,7 +207,7 @@
                                     <ng-container [ngTemplateOutlet]="multiChoiceTpl"></ng-container>
                                 </div>
                             </ng-container>
-                            <ng-container *ngSwitchCase="multiChoiceEnum.SELECT_MULTI">
+                            <ng-container *ngSwitchCase="multiChoiceEnum.SELECT">
                                 <div nz-col [nzXs]="col.xs" [nzSm]="col.sm" [nzMd]="col.md"
                                      [nzLg]="col.lg"
                                      [nzXl]="col.xl"
@@ -219,7 +219,7 @@
                                 <se [label]="field.eruptFieldJson.edit.title"
                                     [required]="field.eruptFieldJson.edit.notNull"
                                     [optionalHelp]="field.eruptFieldJson.edit.desc">
-                                    <erupt-multi-choice [eruptModel]="eruptModel" [eruptField]="field"
+                                    <erupt-multi-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
                                                         [readonly]="isReadonly(field)">
 
                                     </erupt-multi-choice>

--- a/src/app/build/erupt/components/edit-type/edit-type.component.html
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.html
@@ -175,15 +175,7 @@
                         <ng-container [ngSwitch]="field.eruptFieldJson.edit.choiceType.type">
                             <ng-container *ngSwitchCase="choiceEnum.RADIO">
                                 <div nz-col [nzXs]="24">
-                                    <se [label]="field.eruptFieldJson.edit.title"
-                                        [required]="field.eruptFieldJson.edit.notNull"
-                                        [optionalHelp]="field.eruptFieldJson.edit.desc">
-                                        <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
-                                                      [eruptParentName]="parentEruptName" [editType]="this"
-                                                      [readonly]="isReadonly(field)" #choice>
-
-                                        </erupt-choice>
-                                    </se>
+                                    <ng-container [ngTemplateOutlet]="choiceTpl"></ng-container>
                                 </div>
                             </ng-container>
                             <ng-container *ngSwitchCase="choiceEnum.SELECT">
@@ -191,17 +183,48 @@
                                      [nzLg]="col.lg"
                                      [nzXl]="col.xl"
                                      [nzXXl]="col.xxl">
-                                    <se [label]="field.eruptFieldJson.edit.title"
-                                        [required]="field.eruptFieldJson.edit.notNull"
-                                        [optionalHelp]="field.eruptFieldJson.edit.desc">
-                                        <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
-                                                      [eruptParentName]="parentEruptName" [editType]="this"
-                                                      [readonly]="isReadonly(field)" #choice>
-
-                                        </erupt-choice>
-                                    </se>
+                                    <ng-container [ngTemplateOutlet]="choiceTpl"></ng-container>
                                 </div>
                             </ng-container>
+                            <ng-template #choiceTpl>
+                                <se [label]="field.eruptFieldJson.edit.title"
+                                    [required]="field.eruptFieldJson.edit.notNull"
+                                    [optionalHelp]="field.eruptFieldJson.edit.desc">
+                                    <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
+                                                  [eruptParentName]="parentEruptName" [editType]="this"
+                                                  [readonly]="isReadonly(field)" #choice>
+
+                                    </erupt-choice>
+                                </se>
+                            </ng-template>
+                        </ng-container>
+                    </ng-container>
+                    <!--multi-choice-->
+                    <ng-container *ngSwitchCase="editType.MULTI_CHOICE">
+                        <ng-container [ngSwitch]="field.eruptFieldJson.edit.multiChoiceType.type">
+                            <ng-container *ngSwitchCase="multiChoiceEnum.CHECKBOX">
+                                <div nz-col [nzXs]="24">
+                                    <ng-container [ngTemplateOutlet]="multiChoiceTpl"></ng-container>
+                                </div>
+                            </ng-container>
+                            <ng-container *ngSwitchCase="multiChoiceEnum.SELECT_MULTI">
+                                <div nz-col [nzXs]="col.xs" [nzSm]="col.sm" [nzMd]="col.md"
+                                     [nzLg]="col.lg"
+                                     [nzXl]="col.xl"
+                                     [nzXXl]="col.xxl">
+                                    <ng-container [ngTemplateOutlet]="multiChoiceTpl"></ng-container>
+                                </div>
+                            </ng-container>
+                            <ng-template #multiChoiceTpl>
+                                <se [label]="field.eruptFieldJson.edit.title"
+                                    [required]="field.eruptFieldJson.edit.notNull"
+                                    [optionalHelp]="field.eruptFieldJson.edit.desc">
+                                    <erupt-multi-choice [eruptModel]="eruptModel" [eruptField]="field"
+                                                        [readonly]="isReadonly(field)">
+
+                                    </erupt-multi-choice>
+                                </se>
+                            </ng-template>
                         </ng-container>
                     </ng-container>
                     <ng-container *ngSwitchCase="editType.TAGS">

--- a/src/app/build/erupt/components/edit-type/edit-type.component.ts
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.ts
@@ -1,6 +1,14 @@
 import {Component, DoCheck, Inject, Input, OnDestroy, OnInit, QueryList, ViewChildren} from "@angular/core";
 import {EruptFieldModel} from "../../model/erupt-field.model";
-import {AttachmentEnum, ChoiceEnum, EditType, FormSize, HtmlEditTypeEnum, Scene} from "../../model/erupt.enum";
+import {
+    AttachmentEnum,
+    ChoiceEnum,
+    EditType,
+    FormSize,
+    HtmlEditTypeEnum,
+    MultiChoiceEnum,
+    Scene
+} from "../../model/erupt.enum";
 import {DataService} from "@shared/service/data.service";
 import {EruptModel} from "../../model/erupt.model";
 import {colRules} from "@shared/model/util.model";
@@ -54,6 +62,8 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
     htmlEditorType = HtmlEditTypeEnum;
 
     choiceEnum = ChoiceEnum;
+
+    multiChoiceEnum = MultiChoiceEnum;
 
     attachmentEnum = AttachmentEnum;
 

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.html
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.html
@@ -1,6 +1,5 @@
 <ng-container [ngSwitch]="eruptField.eruptFieldJson.edit.multiChoiceType.type">
     <ng-container *ngSwitchCase="multiChoiceEnum.CHECKBOX">
-        {{ this.eruptField.eruptFieldJson.edit.$value }}
         <nz-checkbox-wrapper (nzOnChange)="checkboxChange($event)" class="erupt-input stander-line-height">
             <nz-row>
                 <ng-container *ngFor="let vl of eruptField.componentValue">

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.html
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.html
@@ -14,4 +14,14 @@
             </nz-row>
         </nz-checkbox-wrapper>
     </ng-container>
+
+    <ng-container *ngSwitchCase="multiChoiceEnum.SELECT">
+        <nz-select [(ngModel)]="this.eruptField.eruptFieldJson.edit.$value" [nzSize]="size" nzMode="multiple"
+                   style="width:100%">
+            <nz-option *ngFor="let vl of eruptField.componentValue" [nzLabel]="vl.label"
+                       [nzDisabled]="readonly||vl.disable"
+                       [nzValue]="isNumeric(vl.value)?parseInt(vl.value):vl.value">
+            </nz-option>
+        </nz-select>
+    </ng-container>
 </ng-container>

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.html
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.html
@@ -1,6 +1,6 @@
 <ng-container [ngSwitch]="eruptField.eruptFieldJson.edit.multiChoiceType.type">
     <ng-container *ngSwitchCase="multiChoiceEnum.CHECKBOX">
-        <nz-checkbox-wrapper (nzOnChange)="checkboxChange($event)" class="erupt-input stander-line-height">
+        <nz-checkbox-wrapper (nzOnChange)="checkboxChange($event)" style="width:100%">
             <nz-row>
                 <ng-container *ngFor="let vl of eruptField.componentValue">
                     <nz-col nzSpan="4">

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.html
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.html
@@ -1,0 +1,18 @@
+<ng-container [ngSwitch]="eruptField.eruptFieldJson.edit.multiChoiceType.type">
+    <ng-container *ngSwitchCase="multiChoiceEnum.CHECKBOX">
+        {{ this.eruptField.eruptFieldJson.edit.$value }}
+        <nz-checkbox-wrapper (nzOnChange)="checkboxChange($event)" class="erupt-input stander-line-height">
+            <nz-row>
+                <ng-container *ngFor="let vl of eruptField.componentValue">
+                    <nz-col nzSpan="4">
+                        <label nz-checkbox [nzValue]="vl.value" nz-tooltip [nzDisabled]="readonly||vl.disable"
+                               [nzTooltipTitle]="vl.desc"
+                               [nzChecked]="includes(this.eruptField.eruptFieldJson.edit.$value, vl.value)">
+                            {{ vl.label }}
+                        </label>
+                    </nz-col>
+                </ng-container>
+            </nz-row>
+        </nz-checkbox-wrapper>
+    </ng-container>
+</ng-container>

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.less
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.less
@@ -1,0 +1,14 @@
+:host {
+    ::ng-deep {
+
+        label[nz-checkbox] {
+            //max-width: 140px;
+            //line-height: initial;
+            //margin-left: 0;
+            //margin-bottom: 12px;
+            //overflow: hidden;
+            //white-space: nowrap;
+            //text-overflow: ellipsis;
+        }
+    }
+}

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
@@ -1,0 +1,31 @@
+import {Component, Input} from '@angular/core';
+import {MultiChoiceEnum} from "../../model/erupt.enum";
+import {EruptModel} from "../../model/erupt.model";
+import {EruptFieldModel} from "../../model/erupt-field.model";
+
+@Component({
+  selector: 'erupt-multi-choice',
+  templateUrl: './multi-choice.component.html',
+  styleUrls: ['./multi-choice.component.less']
+})
+export class MultiChoiceComponent {
+
+    @Input() eruptModel: EruptModel;
+
+    @Input() eruptField: EruptFieldModel;
+
+    @Input() readonly: boolean = false;
+
+    multiChoiceEnum = MultiChoiceEnum;
+
+    includes(arr: any[], ele: any) {
+        if (arr) {
+            return arr.some(item => item == ele)
+        }
+        return false;
+    }
+
+    checkboxChange(e: any[]) {
+        this.eruptField.eruptFieldJson.edit.$value = e;
+    }
+}

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
@@ -4,11 +4,11 @@ import {EruptModel} from "../../model/erupt.model";
 import {EruptFieldModel} from "../../model/erupt-field.model";
 
 @Component({
-  selector: 'erupt-multi-choice',
-  templateUrl: './multi-choice.component.html',
-  styleUrls: ['./multi-choice.component.less']
+    selector: 'erupt-multi-choice',
+    templateUrl: './multi-choice.component.html',
+    styleUrls: ['./multi-choice.component.less']
 })
-export class MultiChoiceComponent {
+export class MultiChoiceComponent  {
 
     @Input() eruptModel: EruptModel;
 
@@ -16,7 +16,13 @@ export class MultiChoiceComponent {
 
     @Input() readonly: boolean = false;
 
+    @Input() size: 'large' | 'small' | "default" = "default";
+
     multiChoiceEnum = MultiChoiceEnum;
+
+    isNumeric(str:string): boolean {
+        return !isNaN(parseFloat(str)) && isFinite(parseFloat(str));
+    }
 
     includes(arr: any[], ele: any) {
         if (arr) {
@@ -28,4 +34,6 @@ export class MultiChoiceComponent {
     checkboxChange(e: any[]) {
         this.eruptField.eruptFieldJson.edit.$value = e;
     }
+
+    protected readonly parseInt = parseInt;
 }

--- a/src/app/build/erupt/components/view-type/view-type.component.html
+++ b/src/app/build/erupt/components/view-type/view-type.component.html
@@ -26,11 +26,13 @@
         </ng-container>
 
         <ng-container *ngSwitchCase="viewType.LINK_DIALOG">
-            <iframe [src]="value|safeUrl" [frameBorder]="0" style="display: block;width: 100%;height: 650px;vertical-align: bottom;"></iframe>
+            <iframe [src]="value|safeUrl" [frameBorder]="0"
+                    style="display: block;width: 100%;height: 650px;vertical-align: bottom;"></iframe>
         </ng-container>
 
         <ng-container *ngSwitchCase="viewType.ATTACHMENT_DIALOG">
-            <iframe [src]="value|safeUrl" [frameBorder]="0" style="display: block;width: 100%;height: 650px;vertical-align: bottom;"></iframe>
+            <iframe [src]="value|safeUrl" [frameBorder]="0"
+                    style="display: block;width: 100%;height: 650px;vertical-align: bottom;"></iframe>
         </ng-container>
 
 
@@ -60,28 +62,34 @@
                 <ng-container [ngSwitch]="view.eruptFieldModel.eruptFieldJson.edit.type">
                     <ng-container *ngSwitchCase="editType.TAB_TABLE_ADD">
                         <tab-table
-                                [onlyRead]="true"
-                                [tabErupt]="{eruptBuildModel:eruptBuildModel.tabErupts[view.eruptFieldModel.fieldName]
+                            [onlyRead]="true"
+                            [tabErupt]="{eruptBuildModel:eruptBuildModel.tabErupts[view.eruptFieldModel.fieldName]
                                             ,eruptFieldModel:eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)}"
-                                [eruptBuildModel]="eruptBuildModel"
+                            [eruptBuildModel]="eruptBuildModel"
                         ></tab-table>
                     </ng-container>
                     <ng-container *ngSwitchCase="editType.TAB_TABLE_REFER">
                         <tab-table [onlyRead]="true"
                                    [tabErupt]="{eruptBuildModel:eruptBuildModel.tabErupts[view.eruptFieldModel.fieldName]
-                                ,eruptFieldModel:eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)}"
+                                            ,eruptFieldModel:eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)}"
                                    [eruptBuildModel]="eruptBuildModel" [mode]="'refer-add'"
                         ></tab-table>
                     </ng-container>
                     <ng-container *ngSwitchCase="editType.TAB_TREE">
                         <erupt-tab-tree [onlyRead]="true"
                                         [eruptFieldModel]="eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)"
-                                        [eruptBuildModel]="eruptBuildModel"
-                        ></erupt-tab-tree>
+                                        [eruptBuildModel]="eruptBuildModel"></erupt-tab-tree>
                     </ng-container>
                     <ng-container *ngSwitchCase="editType.CHECKBOX">
                         <erupt-checkbox [eruptBuildModel]="eruptBuildModel" [onlyRead]="true"
-                                        [eruptFieldModel]="eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)"></erupt-checkbox>
+                                        [eruptFieldModel]="eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)">
+                        </erupt-checkbox>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="editType.MULTI_CHOICE">
+                        <erupt-multi-choice [eruptModel]="eruptBuildModel.eruptModel"
+                                            [eruptField]="eruptBuildModel.eruptModel.eruptFieldModelMap.get(view.eruptFieldModel.fieldName)"
+                                            [readonly]="true">
+                        </erupt-multi-choice>
                     </ng-container>
                 </ng-container>
             </nz-spin>

--- a/src/app/build/erupt/erupt.module.ts
+++ b/src/app/build/erupt/erupt.module.ts
@@ -40,6 +40,7 @@ import {NzQRCodeModule} from "ng-zorro-antd/qr-code";
 import {NzRateModule} from "ng-zorro-antd/rate";
 import {AttachmentSelectComponent} from './components/attachment-select/attachment-select.component';
 import {NzEmptyModule} from "ng-zorro-antd/empty";
+import {MultiChoiceComponent} from './components/multi-choice/multi-choice.component';
 
 @NgModule({
     imports: [
@@ -104,7 +105,8 @@ import {NzEmptyModule} from "ng-zorro-antd/empty";
         SafeTemplateComponent,
         MarkdownComponent,
         CardComponent,
-        AttachmentSelectComponent
+        AttachmentSelectComponent,
+        MultiChoiceComponent
     ]
 })
 export class EruptModule {

--- a/src/app/build/erupt/model/erupt-field.model.ts
+++ b/src/app/build/erupt/model/erupt-field.model.ts
@@ -4,6 +4,7 @@ import {
     DateEnum,
     EditType,
     HtmlEditTypeEnum,
+    MultiChoiceEnum,
     PickerMode,
     TabEnum,
     ViewType
@@ -82,6 +83,7 @@ export interface Edit {
     rateType?: RateType;
     boolType?: BoolType;
     choiceType?: ChoiceType;
+    multiChoiceType?: MultiChoiceType;
     tagsType?: TagsType;
     dateType?: DateType;
     sliderType?: SliderType;
@@ -173,6 +175,9 @@ interface ChoiceType {
     onVLChange(value, oldValue): void;
 }
 
+interface MultiChoiceType{
+    type: MultiChoiceEnum;
+}
 
 interface TagsType {
     allowExtension: boolean;

--- a/src/app/build/erupt/model/erupt-field.model.ts
+++ b/src/app/build/erupt/model/erupt-field.model.ts
@@ -32,7 +32,13 @@ export interface Tpl {
     width: string;
     height: string;
     openWay: OpenWay;
+    embedType: PageEmbedType
     drawerPlacement: DrawerPlacement;
+}
+
+export enum PageEmbedType {
+    IFRAME = "IFRAME",
+    MICRO_FRONTEND = "MICRO_FRONTEND"
 }
 
 export enum OpenWay {
@@ -175,7 +181,7 @@ interface ChoiceType {
     onVLChange(value, oldValue): void;
 }
 
-interface MultiChoiceType{
+interface MultiChoiceType {
     type: MultiChoiceEnum;
 }
 

--- a/src/app/build/erupt/model/erupt.enum.ts
+++ b/src/app/build/erupt/model/erupt.enum.ts
@@ -21,7 +21,8 @@ export enum EditType {
     NUMBER = "NUMBER",
     COLOR = "COLOR",
     TEXTAREA = "TEXTAREA",                     //大文本域
-    CHOICE = "CHOICE",                         //选择框
+    CHOICE = "CHOICE",                         //单个选择
+    MULTI_CHOICE = "MULTI_CHOICE",             //多选
     TAGS = "TAGS",                             //标签选择
     DATE = "DATE",                             //日期
     COMBINE = "COMBINE",                       //表格合并
@@ -111,6 +112,11 @@ export enum AttachmentEnum {
 export enum ChoiceEnum {
     RADIO = "RADIO",
     SELECT = "SELECT",
+}
+
+export enum MultiChoiceEnum {
+    SELECT_MULTI = "SELECT_MULTI",
+    CHECKBOX = "CHECKBOX"
 }
 
 export enum SelectMode {

--- a/src/app/build/erupt/model/erupt.enum.ts
+++ b/src/app/build/erupt/model/erupt.enum.ts
@@ -115,7 +115,7 @@ export enum ChoiceEnum {
 }
 
 export enum MultiChoiceEnum {
-    SELECT_MULTI = "SELECT_MULTI",
+    SELECT = "SELECT",
     CHECKBOX = "CHECKBOX"
 }
 

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -75,7 +75,15 @@ export interface Page {
     total?: number;
     sort?: string;
     list?: any[];
+    alert?: Alert;
 }
+
+export interface Alert {
+    message: string;
+    closeable: boolean;
+    uiType: "success" | "info" | "warning" | "error";
+}
+
 
 export interface Tree {
     id: string;

--- a/src/app/build/erupt/service/data-handler.service.ts
+++ b/src/app/build/erupt/service/data-handler.service.ts
@@ -339,11 +339,6 @@ export class DataHandlerService {
                             }
                         }
                         break;
-                    // case EditType.CODE_EDITOR:
-                    //     if (edit.$value || edit.$value === 0) {
-                    //         eruptData[field.fieldName] = btoa(encodeURIComponent(edit.$value))
-                    //     }
-                    //     break;
                     default:
                         if (edit.$value || edit.$value === 0) {
                             eruptData[field.fieldName] = edit.$value;

--- a/src/app/build/erupt/service/data-handler.service.ts
+++ b/src/app/build/erupt/service/data-handler.service.ts
@@ -144,9 +144,13 @@ export class DataHandlerService {
     eruptObjectToCondition(obj: Object): QueryCondition[] {
         let queryCondition: QueryCondition[] = [];
         for (let key in obj) {
+            let val = obj[key];
+            if (typeof val == "string") {
+                val = val.trim();
+            }
             queryCondition.push({
                 key: key,
-                value: obj[key]
+                value: val
             });
         }
         return queryCondition;

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -138,13 +138,14 @@ export class UiBuildService {
                     break;
                 case ViewType.DATE:
                     obj.className = "date-col";
-                    obj.width = 110;
+                    obj.width = 115;
                     obj.format = (item: any) => {
                         if (item[view.column]) {
-                            if (view.eruptFieldModel.eruptFieldJson.edit.dateType.type == DateEnum.DATE) {
-                                return item[view.column].substr(0, 10);
+                            let val = <string>item[view.column];
+                            if (view.eruptFieldModel.eruptFieldJson.edit.dateType.type == DateEnum.DATE && !val.startsWith("<") && !val.endsWith(">")) {
+                                return val.substring(0, 10);
                             } else {
-                                return item[view.column];
+                                return val;
                             }
                         } else {
                             return "";

--- a/src/app/build/erupt/service/ui-build.service.ts
+++ b/src/app/build/erupt/service/ui-build.service.ts
@@ -11,8 +11,9 @@ import {NzModalService} from "ng-zorro-antd/modal";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {NzImageService} from "ng-zorro-antd/image";
 import {EruptIframeComponent} from "@shared/component/iframe.component";
-import {View} from "../model/erupt-field.model";
+import {PageEmbedType, View} from "../model/erupt-field.model";
 import {AttachmentSelectComponent} from "../components/attachment-select/attachment-select.component";
+import {EruptMicroAppComponent} from "@shared/component/micro-app.component";
 
 
 @Injectable()
@@ -575,6 +576,7 @@ export class UiBuildService {
                     let url = this.dataService.getEruptViewTpl(eruptBuildModel.eruptModel.eruptName,
                         view.eruptFieldModel.fieldName,
                         item[eruptBuildModel.eruptModel.eruptJson.primaryKeyCol]);
+                    let isIframe = !view.tpl.embedType || view.tpl.embedType == PageEmbedType.IFRAME;
                     let ref = this.modal.create({
                         nzKeyboard: true,
                         nzMaskClosable: false,
@@ -586,7 +588,8 @@ export class UiBuildService {
                             padding: "0"
                         },
                         nzFooter: null,
-                        nzContent: EruptIframeComponent
+                        // @ts-ignore
+                        nzContent: isIframe ? EruptIframeComponent : EruptMicroAppComponent
                     });
                     ref.getContentComponent().url = url;
                 };

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -13,7 +13,8 @@
                     <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.rowOperation">
                         <ng-container *ngFor="let item of eruptBuildModel.eruptModel.eruptJson.rowOperation">
                             <ng-container *ngIf="item.mode != operationMode.SINGLE">
-                                <button nz-button nzType="dashed" class="mb-sm" [nz-tooltip]="item.tip" (click)="createOperator(item)">
+                                <button nz-button nzType="dashed" class="mb-sm" [nz-tooltip]="item.tip"
+                                        (click)="createOperator(item)">
                                     <i *ngIf="item.icon" class="fa" [ngClass]="item.icon" style="margin-right: 8px"></i>
                                     <span>{{ item.title }}</span>
                                 </button>
@@ -114,6 +115,14 @@
                 </div>
 
                 <ng-container *ngIf="eruptBuildModel.eruptModel.eruptJson.power.query">
+                    <ng-container *ngIf="alert">
+                        <nz-alert style="margin-bottom:8px" [nzMessage]="alertMessage" [nzType]="alert.uiType"
+                                  [nzCloseable]="alert.closeable" (nzOnClose)="alert = null">
+                        </nz-alert>
+                        <ng-template #alertMessage>
+                            <span [innerHTML]="alert.message | safeHtml"></span>
+                        </ng-template>
+                    </ng-container>
                     <nz-card *ngIf="hasSearchFields" [nzBodyStyle]="{padding:'10px'}" class="search-card"
                              [hidden]="hideCondition">
                         <erupt-search [searchEruptModel]="searchErupt" (search)="query()" [size]="'default'">

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, Input, OnDestroy, OnInit, ViewChild} from "@angular/core";
 import {DataService} from "@shared/service/data.service";
-import {Drill, DrillInput, EruptModel, Power, Row, RowOperation} from "../../model/erupt.model";
+import {Alert, Drill, DrillInput, EruptModel, Power, Row, RowOperation} from "../../model/erupt.model";
 
 import {SettingsService} from "@delon/theme";
 import {EditTypeComponent} from "../../components/edit-type/edit-type.component";
@@ -77,7 +77,9 @@ export class TableComponent implements OnInit, OnDestroy {
 
     clientHeight: number = document.body.clientHeight;
 
-    hideCondition = false;
+    hideCondition: boolean = false;
+
+    alert: Alert;
 
     searchErupt: EruptModel;
 
@@ -312,9 +314,7 @@ export class TableComponent implements OnInit, OnDestroy {
             this.dataPage.querying = false;
             this.dataPage.data = page.list || [];
             this.dataPage.total = page.total;
-            // for (let ele of spliceArr(page.list, 20)) {
-            //     this.dataPage.data.push(...ele)
-            // }
+            this.alert = page.alert;
         })
         this.extraRowFun(query);
     }

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -908,9 +908,11 @@ export class TableComponent implements OnInit, OnDestroy {
     exportExcel() {
         let condition = null;
         if (this.searchErupt && this.searchErupt.eruptFieldModels.length > 0) {
-            condition = this.dataHandler.eruptObjectToCondition(this.dataHandler.eruptValueToObject({
-                eruptModel: this.searchErupt
-            }));
+            condition = this.dataHandler.eruptObjectToCondition(
+                this.dataHandler.searchEruptToObject({
+                    eruptModel: this.searchErupt
+                })
+            );
         }
         //导出接口
         this.downloading = true;

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -19,7 +19,7 @@ import {
 import {DataHandlerService} from "../../service/data-handler.service";
 import {ExcelImportComponent} from "../../components/excel-import/excel-import.component";
 import {Status} from "../../model/erupt-api.model";
-import {EruptFieldModel, OpenWay} from "../../model/erupt-field.model";
+import {DrawerPlacement, EruptFieldModel, OpenWay} from "../../model/erupt-field.model";
 import {Observable} from "rxjs";
 import {EruptIframeComponent} from "@shared/component/iframe.component";
 import {UiBuildService} from "../../service/ui-build.service";
@@ -656,12 +656,13 @@ export class TableComponent implements OnInit, OnDestroy {
                 });
                 ref.getContentComponent().url = url;
             } else {
+                let placement = ro.tpl.drawerPlacement;
                 this.drawerService.create({
-                    nzTitle: ro.title,
+                    nzClosable: false,
                     nzKeyboard: true,
                     nzMaskClosable: true,
                     // @ts-ignore
-                    nzPlacement: ro.tpl.drawerPlacement.toLowerCase(),
+                    nzPlacement: placement.toLowerCase(),
                     nzWidth: ro.tpl.width || "40%",
                     nzHeight: ro.tpl.height || "40%",
                     nzBodyStyle: {
@@ -670,7 +671,9 @@ export class TableComponent implements OnInit, OnDestroy {
                     nzFooter: null,
                     nzContent: EruptIframeComponent,
                     nzContentParams: {
-                        url: url
+                        url: url,
+                        height: (placement == DrawerPlacement.LEFT || placement == DrawerPlacement.RIGHT) ? "100vh" : ro.tpl.height,
+                        width: (placement == DrawerPlacement.TOP || placement == DrawerPlacement.BOTTOM) ? "100vw" : ro.tpl.width
                     }
                 })
             }

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -19,7 +19,7 @@ import {
 import {DataHandlerService} from "../../service/data-handler.service";
 import {ExcelImportComponent} from "../../components/excel-import/excel-import.component";
 import {Status} from "../../model/erupt-api.model";
-import {DrawerPlacement, EruptFieldModel, OpenWay} from "../../model/erupt-field.model";
+import {DrawerPlacement, EruptFieldModel, OpenWay, PageEmbedType} from "../../model/erupt-field.model";
 import {Observable} from "rxjs";
 import {EruptIframeComponent} from "@shared/component/iframe.component";
 import {UiBuildService} from "../../service/ui-build.service";
@@ -35,6 +35,7 @@ import {AppViewService} from "@shared/service/app-view.service";
 import {CodeEditorComponent} from "../../components/code-editor/code-editor.component";
 import {NzDrawerService} from "ng-zorro-antd/drawer";
 import {TableStyle} from "../../model/erupt.vo";
+import {EruptMicroAppComponent} from "@shared/component/micro-app.component";
 
 
 @Component({
@@ -637,6 +638,7 @@ export class TableComponent implements OnInit, OnDestroy {
         if (ro.type === OperationType.TPL) {
             let url = this.dataService.getEruptOperationTpl(this.eruptBuildModel.eruptModel.eruptName, ro.code, ids);
             if (!ro.tpl.openWay || ro.tpl.openWay == OpenWay.MODAL) {
+                let isIframe = !ro.tpl.embedType || ro.tpl.embedType == PageEmbedType.IFRAME;
                 let ref = this.modal.create({
                     nzKeyboard: true,
                     nzTitle: ro.title,
@@ -649,7 +651,8 @@ export class TableComponent implements OnInit, OnDestroy {
                         padding: "0"
                     },
                     nzFooter: null,
-                    nzContent: EruptIframeComponent,
+                    // @ts-ignore
+                    nzContent: isIframe ? EruptIframeComponent : EruptMicroAppComponent,
                     nzOnCancel: () => {
                         // this.query();
                     }

--- a/src/app/build/tpl/tpl.component.html
+++ b/src/app/build/tpl/tpl.component.html
@@ -1,7 +1,4 @@
 <div class="page-container">
-    <nz-spin [nzSpinning]="spin" style="height:100%;width: 100%">
-        <iframe (load)="iframeLoad()" [src]="url | safeUrl"
-                style="border: 0;vertical-align:bottom" height="100%" width="100%">
-        </iframe>
-    </nz-spin>
+    <erupt-iframe *ngIf="!micro" [url]="url" [width]="'100%'" [height]="'100%'"></erupt-iframe>
+    <erupt-micro-app *ngIf="micro" [url]="url"></erupt-micro-app>
 </div>

--- a/src/app/build/tpl/tpl.component.ts
+++ b/src/app/build/tpl/tpl.component.ts
@@ -14,7 +14,8 @@ export class TplComponent implements OnInit, OnDestroy {
 
     name: string;
 
-    spin: boolean = true;
+    //是否使用微前端嵌入
+    micro: boolean = false;
 
     private router$: Subscription;
 
@@ -25,23 +26,22 @@ export class TplComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.router$ = this.route.params.subscribe((params) => {
+        this.router$ = this.route.params.subscribe(() => {
             let url = this.router.url;
             let tpl = '/tpl/';
+            let mtpl = '/mtpl/';
+            if (url.startsWith(mtpl)) {
+                tpl = mtpl;
+            }
             this.name = url.substring(url.indexOf(tpl) + tpl.length);
             this.url = this.dataService.getEruptTpl(this.name);
+            this.micro = this.route.snapshot.data['micro']
         });
-        setTimeout(() => {
-            this.spin = false;
-        }, 3000)
+
     }
 
     ngOnDestroy(): void {
         this.router$.unsubscribe();
-    }
-
-    iframeLoad() {
-        this.spin = false;
     }
 
 }

--- a/src/app/build/tpl/tpl.module.ts
+++ b/src/app/build/tpl/tpl.module.ts
@@ -1,4 +1,4 @@
-import {CUSTOM_ELEMENTS_SCHEMA, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {TplComponent} from './tpl.component';
@@ -12,9 +12,6 @@ import {SharedModule} from "@shared/shared.module";
         CommonModule,
         TplRoutingModule,
         SharedModule,
-    ],
-    schemas: [
-        CUSTOM_ELEMENTS_SCHEMA
     ]
 })
 export class TplModule {

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -32,7 +32,7 @@ let coreRouter: Routes = [
     {
         path: "tpl/:name",
         pathMatch: "full",
-        loadChildren: () => import( "../build/tpl/tpl.module").then(m => m.TplModule)
+        loadChildren: () => tplLoad.then(m => m.TplModule)
     },
     {
         path: 'tpl/:name/:name2',
@@ -52,6 +52,47 @@ let coreRouter: Routes = [
     {
         path: 'tpl/:name/:name2/:name3/:name4/:name5',
         pathMatch: "full",
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+
+    {
+        path: "mtpl/:name",
+        pathMatch: "full",
+        data: {
+            micro: true
+        },
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+    {
+        path: 'mtpl/:name/:name2',
+        pathMatch: "full",
+        data: {
+            micro: true
+        },
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+    {
+        path: 'mtpl/:name/:name2/:name3',
+        pathMatch: "full",
+        data: {
+            micro: true
+        },
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+    {
+        path: 'mtpl/:name/:name2/:name3/:name4',
+        pathMatch: "full",
+        data: {
+            micro: true
+        },
+        loadChildren: () => tplLoad.then(m => m.TplModule)
+    },
+    {
+        path: 'mtpl/:name/:name2/:name3/:name4/:name5',
+        pathMatch: "full",
+        data: {
+            micro: true
+        },
         loadChildren: () => tplLoad.then(m => m.TplModule)
     }
 ];

--- a/src/app/shared/component/iframe.component.ts
+++ b/src/app/shared/component/iframe.component.ts
@@ -41,9 +41,9 @@ export class EruptIframeComponent implements OnInit {
         if (this.width) {
             this.style["width"] = this.width;
         }
-        setTimeout(()=>{
+        setTimeout(() => {
             this.spin = false;
-        },3000)
+        }, 3000)
     }
 
     iframeLoad(event: any) {

--- a/src/app/shared/component/iframe.component.ts
+++ b/src/app/shared/component/iframe.component.ts
@@ -7,7 +7,7 @@ import {IframeHeight} from "@shared/util/window.util";
         <nz-spin [nzSpinning]="spin">
             <iframe [src]="url|safeUrl" style="width: 100%;border: 0;display: block;vertical-align: bottom;"
                     [ngStyle]="style"
-                    (load)="iframeHeight($event)">
+                    (load)="iframeLoad($event)">
 
             </iframe>
         </nz-spin>
@@ -16,9 +16,11 @@ import {IframeHeight} from "@shared/util/window.util";
 })
 export class EruptIframeComponent implements OnInit, OnChanges {
 
-    @Input() url: string | undefined;
+    @Input() url: string | null;
 
-    @Input() height: string | undefined;
+    @Input() height: string | null;
+
+    @Input() width: string | null;
 
     @Input() style: object = {};
 
@@ -32,17 +34,20 @@ export class EruptIframeComponent implements OnInit, OnChanges {
         this.spin = true;
     }
 
-    iframeHeight(event: any) {
+    iframeLoad(event: any) {
         this.spin = false;
-        if (!this.height) {
+        if (this.height) {
+            this.style["height"] = this.height;
+        } else {
             try {
                 IframeHeight(event);
             } catch (e) {
                 this.style["height"] = "600px"
                 console.error(e)
             }
-        } else {
-            this.style["height"] = this.height;
+        }
+        if (this.width) {
+            this.style["width"] = this.width;
         }
         this.spin = false;
     };

--- a/src/app/shared/component/iframe.component.ts
+++ b/src/app/shared/component/iframe.component.ts
@@ -1,11 +1,12 @@
-import {Component, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {IframeHeight} from "@shared/util/window.util";
 
 @Component({
     selector: 'erupt-iframe',
     template: `
-        <nz-spin [nzSpinning]="spin">
-            <iframe [src]="url|safeUrl" style="width: 100%;border: 0;display: block;vertical-align: bottom;"
+        <nz-spin [nzSpinning]="spin" style="height: 100%;width: 100%">
+            <iframe [src]="url|safeUrl" height="100%"
+                    style="width: 100%;height: 100%;border: 0;display: block;vertical-align: bottom;"
                     [ngStyle]="style"
                     (load)="iframeLoad($event)">
 
@@ -14,7 +15,7 @@ import {IframeHeight} from "@shared/util/window.util";
     `,
     styles: []
 })
-export class EruptIframeComponent implements OnInit, OnChanges {
+export class EruptIframeComponent implements OnInit {
 
     @Input() url: string | null;
 
@@ -32,13 +33,22 @@ export class EruptIframeComponent implements OnInit, OnChanges {
 
     ngOnInit() {
         this.spin = true;
+        if (this.height) {
+            this.style["height"] = this.height;
+        } else {
+            this.style["height"] = "100%";
+        }
+        if (this.width) {
+            this.style["width"] = this.width;
+        }
+        setTimeout(()=>{
+            this.spin = false;
+        },3000)
     }
 
     iframeLoad(event: any) {
         this.spin = false;
-        if (this.height) {
-            this.style["height"] = this.height;
-        } else {
+        if (!this.height) {
             try {
                 IframeHeight(event);
             } catch (e) {
@@ -46,17 +56,7 @@ export class EruptIframeComponent implements OnInit, OnChanges {
                 console.error(e)
             }
         }
-        if (this.width) {
-            this.style["width"] = this.width;
-        }
         this.spin = false;
     };
-
-    ngOnChanges(changes: SimpleChanges): void {
-        // if (!changes.url.firstChange) {
-        //   this.spin = true;
-        // }
-    }
-
 
 }

--- a/src/app/shared/component/micro-app.component.less
+++ b/src/app/shared/component/micro-app.component.less
@@ -1,0 +1,15 @@
+[data-theme='dark'] {
+    :host {
+        ::ng-deep {
+            #erupt-micro-app-ele {
+                background: #000 !important;
+            }
+        }
+    }
+}
+
+:host {
+    #erupt-micro-app-ele {
+        background: #fff;
+    }
+}

--- a/src/app/shared/component/micro-app.component.ts
+++ b/src/app/shared/component/micro-app.component.ts
@@ -25,13 +25,13 @@ export class EruptMicroAppComponent implements AfterViewInit {
         if (!this.eruptContextService.has(ContextKey.INIT_MICRO_APP)) {
             this.eruptContextService.set(ContextKey.INIT_MICRO_APP, true);
             microApp.start({
-                'router-mode': 'pure'
+                'router-mode': 'native',
+                // shadowDOM: true
             });
         }
     }
 
     ngAfterViewInit() {
-        console.log(this.url)
         this.microApp.nativeElement.setAttribute('url', this.url);
     }
 

--- a/src/app/shared/component/micro-app.component.ts
+++ b/src/app/shared/component/micro-app.component.ts
@@ -1,0 +1,38 @@
+import {AfterViewInit, Component, ElementRef, Input, ViewChild} from '@angular/core';
+import microApp from '@micro-zoe/micro-app'
+import {ContextKey, EruptContextService} from "@shared/service/erupt-context.service";
+
+@Component({
+    selector: 'erupt-micro-app',
+    template: `
+        <micro-app #microApp name="erupt-micro-app-ele"
+                   style="width: 100%;height: 100%;display: block">
+
+        </micro-app>
+    `,
+    styles: []
+})
+export class EruptMicroAppComponent implements AfterViewInit {
+
+    @Input() url: string | null;
+
+    spin: boolean = false;
+
+    @ViewChild('microApp') microApp: ElementRef;
+
+    constructor(private eruptContextService: EruptContextService) {
+        if (!this.eruptContextService.has(ContextKey.INIT_MICRO_APP)) {
+            this.eruptContextService.set(ContextKey.INIT_MICRO_APP, true);
+            microApp.start({
+                'router-mode': 'pure'
+            });
+        }
+    }
+
+    ngAfterViewInit() {
+        console.log(this.url)
+        this.microApp.nativeElement.setAttribute('url', this.url);
+    }
+
+
+}

--- a/src/app/shared/component/micro-app.component.ts
+++ b/src/app/shared/component/micro-app.component.ts
@@ -5,12 +5,13 @@ import {ContextKey, EruptContextService} from "@shared/service/erupt-context.ser
 @Component({
     selector: 'erupt-micro-app',
     template: `
-        <micro-app #microApp name="erupt-micro-app-ele"
+        <micro-app #microApp name="erupt-micro-app-ele" id="erupt-micro-app-ele"
                    style="width: 100%;height: 100%;display: block">
 
         </micro-app>
     `,
-    styles: []
+    styles: [],
+    styleUrls: ['./micro-app.component.less'],
 })
 export class EruptMicroAppComponent implements AfterViewInit {
 

--- a/src/app/shared/model/erupt-menu.ts
+++ b/src/app/shared/model/erupt-menu.ts
@@ -20,4 +20,5 @@ export enum MenuTypeEnum {
     selfWindow = "selfWindow",
     bi = "bi",
     tpl = "tpl",
+    mtpl = "mtpl",
 }

--- a/src/app/shared/service/erupt-context.service.ts
+++ b/src/app/shared/service/erupt-context.service.ts
@@ -1,8 +1,9 @@
 import {Injectable} from "@angular/core";
 
+//Global Context Service
 
 export enum ContextKey {
-
+    INIT_MICRO_APP
 }
 
 @Injectable()
@@ -18,4 +19,7 @@ export class EruptContextService {
         return this.contextValue[key];
     }
 
+    has(key: ContextKey): boolean {
+        return !!this.contextValue[key];
+    }
 }

--- a/src/app/shared/service/socket.service.ts
+++ b/src/app/shared/service/socket.service.ts
@@ -25,11 +25,11 @@ export class SocketService {
         this.reconnectAttempts = 0;
         let websocketUrl: string;
         if (WindowModel.domain) {
-            websocketUrl = (WindowModel.domain.startsWith('http:') ? 'ws:' : 'wss:') + location.host.split(":")[1];
+            websocketUrl = (WindowModel.domain.startsWith('http:') ? 'ws:' : 'wss:') + location.host.split(":")[1] + "/";
         } else {
-            websocketUrl = (location.protocol === 'http:' ? 'ws:' : 'wss:') + "//" + location.host;
+            websocketUrl = (location.protocol === 'http:' ? 'ws:' : 'wss:') + "//" + location.host + location.pathname;
         }
-        this.socket = new WebSocket(websocketUrl + '/erupt?token=' + this.tokenService.get().token);
+        this.socket = new WebSocket(websocketUrl + 'erupt?token=' + this.tokenService.get().token);
 
         this.socket.onopen = () => {
             // 启动心跳

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {NgModule, Type} from '@angular/core';
+import {CUSTOM_ELEMENTS_SCHEMA, NgModule, Type} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {DelonACLModule} from '@delon/acl';
@@ -24,6 +24,7 @@ import {UEditorComponent} from "@shared/component/ueditor/ueditor.component";
 import {EruptContextService} from "@shared/service/erupt-context.service";
 import {UtilsService} from "@shared/service/utils.service";
 import {SocketService} from "@shared/service/socket.service";
+import {EruptMicroAppComponent} from "@shared/component/micro-app.component";
 
 // #region third libs
 // import { NgxTinymceModule } from 'ngx-tinymce';
@@ -32,7 +33,7 @@ const THIRDMODULES: Array<Type<any>> = [];
 // #endregion
 
 // #region your componets & directives
-const COMPONENTS: Array<Type<any>> = [EruptIframeComponent, NavComponent, HeaderI18nComponent, StProgressComponent, UEditorComponent];
+const COMPONENTS: Array<Type<any>> = [EruptIframeComponent, EruptMicroAppComponent, NavComponent, HeaderI18nComponent, StProgressComponent, UEditorComponent];
 const DIRECTIVES: Array<Type<any>> = [RipperDirective, SafeHtmlPipe, SafeScriptPipe, SafeUrlPipe, I18nPipe];
 
 // #endregion
@@ -77,6 +78,9 @@ const DIRECTIVES: Array<Type<any>> = [RipperDirective, SafeHtmlPipe, SafeScriptP
         // your components
         ...COMPONENTS,
         ...DIRECTIVES
+    ],
+    schemas: [
+        CUSTOM_ELEMENTS_SCHEMA
     ]
 })
 export class SharedModule {

--- a/src/app/shared/util/erupt.util.ts
+++ b/src/app/shared/util/erupt.util.ts
@@ -27,6 +27,8 @@ function joinPath(type: string, value: string): string {
             return "/bi/" + menuValue;
         case MenuTypeEnum.tpl:
             return "/tpl/" + menuValue;
+        case MenuTypeEnum.mtpl:
+            return "/mtpl/" + menuValue;
         case MenuTypeEnum.router:
             return menuValue;
         case MenuTypeEnum.newWindow:

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -20,6 +20,24 @@ body.color-gray{
 }
 
 
+
+
+/* 滚动条轨道样式 */
+::-webkit-scrollbar-track {
+    background: #f1f1f1; /* 轨道颜色 */
+}
+
+/* 滚动条滑块样式 */
+::-webkit-scrollbar-thumb {
+    background-color: #888888; /* 滑块颜色 */
+    border-radius: 4px; /* 滑块圆角 */
+}
+
+/* 滑块悬停时的样式 */
+::-webkit-scrollbar-thumb:hover {
+    background-color: #767676; /* 滑块悬停时颜色 */
+}
+
 * {
     scrollbar-width: thin;
     scrollbar-color: #888888 #f1f1f1;


### PR DESCRIPTION
🐞 修复数据库异常不显示中文提示的 bug
🐞 修复 i18n 文件如果引号中携带逗号读取错位的 bug
🐞 解决 id 超过 js 极限数值长度导致精度丢失的 bug
🐞 解决搜索场景与导入场景参数传递不一致的 bug
🧩 源代码中移除 erupt-flow 模块
🧩 升级amis版本到6.10版本
🧩 搜索时自动去除首尾空格
🧩 修改 erupt-magic-api 默认图标与名称
🧩 修改菜单时当前用户无需重新登录，刷新后自动生效
🧩 erupt-tenant 修复已知 bug，租户管理增加联系人字段
🧩 抽屉形式的弹出层将不会渲染页头，同时使用更加友好的宽高适应度
🌟 支持初始化时[默认账号密码配置](https://www.yuque.com/erupts/erupt/gtp7iw#h3nEy)
🌟 自研 session 实现，非 redisSession 场景将不依赖 cookie，
🌟 支持非 redisSession 场景下在线用户查看能力
🌟 增加多选组件 [MULTI_CHOICE](https://www.yuque.com/erupts/erupt/hvd6dk055wtspd0b)
🌟erupt-tpl支持[ path 路径传参](https://www.yuque.com/erupts/erupt/sgx66o#IBWWA)并且通过模板引擎通过变量名称获取。
🌟 在线日志支持搜索，链接跳转，优化日志样式
🌟 erupt-bi 报表增加文本提示组件
🌟 dataProxy 支持 [alert](https://www.yuque.com/erupts/erupt/nicqg3#fQSPY) 能力，在渲染数据的同时增加全局提示
🌟 [引入微前端能力](https://www.yuque.com/erupts/erupt/sgx66o#m2B26)，自定义模板支持微前端方式嵌入
🌟 自定义按钮 @Tpl 注解支持微前端方式渲染