### PR TITLE
TAB_TABLE_REFER多对多表引用组件支持根据前端已录入的信息过滤弹窗数据

### DIFF
--- a/src/app/build/erupt/components/tab-table/tab-table.component.ts
+++ b/src/app/build/erupt/components/tab-table/tab-table.component.ts
@@ -194,6 +194,19 @@ export class TabTableComponent implements OnInit {
     }
 
     addDataByRefer() {
+        let eruptModel = this.eruptBuildModel.eruptModel;
+        let depend = this.tabErupt.eruptFieldModel.eruptFieldJson.edit.referenceTableType.dependField;
+        let dependVal = null;
+        if (depend) {
+            const dependField: EruptFieldModel = eruptModel.eruptFieldModelMap.get(depend);
+            if (dependField.eruptFieldJson.edit.$value) {
+                dependVal = dependField.eruptFieldJson.edit.$value;
+            } else {
+                this.msg.warning("请先选择" + dependField.eruptFieldJson.edit.title);
+                return;
+            }
+        }
+
         let ref = this.modal.create({
             nzStyle: {top: "20px"},
             nzWrapClassName: "modal-xxl",
@@ -248,7 +261,8 @@ export class TabTableComponent implements OnInit {
             eruptBuild: this.eruptBuildModel,
             eruptField: this.tabErupt.eruptFieldModel,
             mode: SelectMode.checkbox,
-            tabRef: true
+            tabRef: true,
+            dependVal:dependVal
         })
     }
 


### PR DESCRIPTION
测试版本：2.1.18
1.问题说明：
  目前组件TAB_TABLE_REFER多对多表引用组件不支持根据前端已录入的信息过滤可选择数据。

2.优化方案：
  参考多对一表引用 REFERENCE_TABLE的联动效果实现，扩展ReferenceTableType注解支持的主键类型，如下图：
![image](https://github.com/user-attachments/assets/93e82bca-e0fc-42f6-9c53-24e44d2bb0bd)
  同时修改前端tab-table组件的addDataByRefer()方法，传递dependField字段指定的过滤值。
![image](https://github.com/user-attachments/assets/11fa53f6-d274-4309-b743-1a7ee1f3e22b)


3.效果如下：

![image](https://github.com/user-attachments/assets/f0309fa0-c7a1-415f-9cc3-9ea00200f8ab)
![image](https://github.com/user-attachments/assets/28da54dd-3cf0-43a4-96f5-49d07e5fe5b0)
![image](https://github.com/user-attachments/assets/67382943-9430-4eec-9e27-0de129e6b8e9)
![image](https://github.com/user-attachments/assets/40780f89-ec09-4b3a-85a2-5440a1ce5263)

