### PR TITLE
1.12.20

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ window.eruptSiteConfig = {
     //     return "x_x_x<a>xxx</a>";
     // },
     logoPath: null,
+    logoFoldPath: null,
     loginLogoPath: null,
     logoText: "Erupt",
     registerPage: null,
@@ -38,19 +39,12 @@ window.eruptSiteConfig = {
         }
     }, {
         text: "star",
-        icon: "fa-eercast",
-        mobileHidden: true,
-        click: function (event) {
-            let ele = `<a class="align-self-center" href='https://gitee.com/erupt/erupt' target="_blank">
+        render: `<a class="align-self-center" href='https://gitee.com/erupt/erupt' target="_blank">
                     <img alt='gitee star' src='https://gitee.com/erupt/erupt/badge/star.svg?theme=dark'/>
                 </a>&nbsp;<a class="align-self-center" href='https://github.com/erupts/erupt' target="_blank">
                     <img alt="github star" src="https://img.shields.io/github/stars/erupts/erupt?style=social">
-                </a> `
-            if (start) {
-                event.target.outerHTML = ele;
-                start = false;
-            }
-        }
+                </a>`,
+        mobileHidden: true
     }],
     login: function (e) {
 

--- a/src/app.js
+++ b/src/app.js
@@ -16,34 +16,41 @@ window.eruptSiteConfig = {
     registerPage: null,
     amapKey: '6ed167be6d22b8f8fa8e0402724df150',
     amapSecurityJsCode: "ee3e78fcb019e6078fcfc5b53b0a63ec",
+    userTools: [{
+        text: "自定义用户工具栏",
+        icon: "fa fa-snowflake-o",
+        click: function (event) {
+            alert("On Click")
+        }
+    }],
     r_tools: [{
-        text: "qq",
         mobileHidden: true,
         icon: "fa-qq",
         click: function (event) {
             window.open("https://jq.qq.com/?_wv=1027&k=MCd4plZ0")
         }
     }, {
-        text: "github",
         mobileHidden: true,
         icon: "fa-github",
         click: function (event) {
             window.open("https://github.com/erupts/erupt")
         }
     }, {
-        text: "gitee",
         mobileHidden: true,
         icon: "fa-github-alt",
         click: function (event) {
             window.open("https://gitee.com/erupt/erupt")
         }
     }, {
-        text: "star",
-        render: `<a class="align-self-center" href='https://gitee.com/erupt/erupt' target="_blank">
-                    <img alt='gitee star' src='https://gitee.com/erupt/erupt/badge/star.svg?theme=dark'/>
-                </a>&nbsp;<a class="align-self-center" href='https://github.com/erupts/erupt' target="_blank">
-                    <img alt="github star" src="https://img.shields.io/github/stars/erupts/erupt?style=social">
-                </a>`,
+        render: () => {
+            return `<div style="padding: 0 6px">
+                    <a class="align-self-center" href='https://gitee.com/erupt/erupt' target="_blank">
+                        <img alt='gitee star' src='https://gitee.com/erupt/erupt/badge/star.svg?theme=dark'/>
+                    </a>&nbsp;<a class="align-self-center" href='https://github.com/erupts/erupt' target="_blank">
+                        <img alt="github star" src="https://img.shields.io/github/stars/erupts/erupt?style=social">
+                    </a>
+                </div>`
+        },
         mobileHidden: true
     }],
     login: function (e) {

--- a/src/app/build/bi/dimension/dimension.component.ts
+++ b/src/app/build/bi/dimension/dimension.component.ts
@@ -35,6 +35,7 @@ export class DimensionComponent implements OnInit {
     ngOnInit() {
         this.dateRanges = <any>{
             [this.i18n.fanyi("global.today")]: [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            [this.i18n.fanyi("global.yesterday")]: [this.datePipe.transform(moment().add(-1, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(moment().add(-1, 'day').toDate(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.last_7_day")]: [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.last_30_day")]: [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.this_month")]: [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],

--- a/src/app/build/erupt/components/choice/choice.component.html
+++ b/src/app/build/erupt/components/choice/choice.component.html
@@ -38,13 +38,24 @@
     </ng-container>
 </ng-container>
 <ng-container *ngIf="vagueSearch">
-    <tag-select [expandable]="true" style="margin-left: 0;">
-        <nz-spin nzSimple *ngIf="isLoading"></nz-spin>
-        <nz-tag (nzCheckedChange)="changeTagAll($event)" style="margin-right: 10px"
-                nzMode="checkable">{{ 'global.check_all'|translate }}
-        </nz-tag>
-        <ng-container *ngFor="let vl of choiceVL">
-            <nz-tag style="margin-right: 10px" nzMode="checkable" [(nzChecked)]="vl.$viewValue">{{ vl.label }}</nz-tag>
+    <nz-select class="erupt-input"
+               (nzOpenChange)="load($event)" [nzLoading]="isLoading"
+               [nzDisabled]="readonly" nzAllowClear
+               [(ngModel)]="eruptField.eruptFieldJson.edit.$value"
+               (ngModelChange)="valueChange($event)"
+               [nzPlaceHolder]="eruptField.eruptFieldJson.edit.placeHolder"
+               nzMode="multiple"
+               [name]="eruptField.fieldName" [nzSize]="size" [nzShowSearch]="true">
+        <ng-container *ngIf="!isLoading">
+            <nz-option *ngFor="let vl of choiceVL" nzCustomContent
+                       [nzDisabled]="vl.disable" [nzValue]="vl.value" [nzLabel]="vl.label">
+                <div nz-tooltip [nzTooltipPlacement]="'left'" [nzTooltipTitle]="vl.desc">{{ vl.label }}</div>
+            </nz-option>
         </ng-container>
-    </tag-select>
+        <nz-option *ngIf="isLoading" nzDisabled nzCustomContent>
+            <div class="text-center">
+                <i nz-icon nzType="loading" class="loading-icon"></i>
+            </div>
+        </nz-option>
+    </nz-select>
 </ng-container>

--- a/src/app/build/erupt/components/choice/choice.component.ts
+++ b/src/app/build/erupt/components/choice/choice.component.ts
@@ -31,9 +31,6 @@ export class ChoiceComponent implements OnInit {
 
     @Input() size: 'large' | 'small' | "default" = "default";
 
-    //是否开启联动功能
-    @Input() dependLinkage = true;
-
     isLoading = false;
 
     choiceEnum = ChoiceEnum;
@@ -44,17 +41,27 @@ export class ChoiceComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.vagueSearch) {
-            this.choiceVL = this.eruptField.componentValue
-            return;
-        }
-        let choiceType = this.eruptField.eruptFieldJson.edit.choiceType;
-        if (choiceType.anewFetch) {
-            if (choiceType.type == ChoiceEnum.RADIO) {
-                this.load(true);
-            }
-        }
-        if (!this.dependLinkage || !choiceType.dependField) {
+        if (this.eruptField.eruptFieldJson.edit.choiceType.dependField) {
+            this.eruptModel.eruptFieldModelMap.get(this.eruptField.eruptFieldJson.edit.choiceType.dependField).eruptFieldJson.edit.$valueSubject?.asObservable().subscribe(val => {
+                let choiceType = this.eruptField.eruptFieldJson.edit.choiceType;
+                if (choiceType.dependExpr == '') {
+                    this.dataService.findChoiceItemFilter(this.eruptModel.eruptName, this.eruptField.fieldName, this.getFromData(), this.eruptParentName).subscribe(data => {
+                        this.choiceVL = data;
+                    })
+                } else {
+                    this.choiceVL = this.eruptField.componentValue.filter(vl => {
+                        try {
+                            return eval(choiceType.dependExpr);
+                        } catch (e) {
+                            this.msg.error(e);
+                        }
+                    })
+                }
+                if (this.choiceVL.filter(it => it.value == this.eruptField.eruptFieldJson.edit.$value).length == 0) {
+                    this.eruptField.eruptFieldJson.edit.$value = null;
+                }
+            })
+        } else {
             this.choiceVL = this.eruptField.componentValue
         }
     }
@@ -73,24 +80,12 @@ export class ChoiceComponent implements OnInit {
         }
     }
 
-    //依赖值发生变化
-    dependChange(value) {
-        let choiceType = this.eruptField.eruptFieldJson.edit.choiceType;
-        if (choiceType.dependField) {
-            let dependValue = value;
-            for (let eruptFieldModel of this.eruptModel.eruptFieldModels) {
-                if (eruptFieldModel.fieldName == choiceType.dependField) {
-                    this.choiceVL = this.eruptField.componentValue.filter(vl => {
-                        try {
-                            return eval(choiceType.dependExpr);
-                        } catch (e) {
-                            this.msg.error(e);
-                        }
-                    })
-                    break;
-                }
-            }
+    getFromData(): any {
+        let result = {};
+        for (let eruptFieldModel of this.eruptModel.eruptFieldModels) {
+            result[eruptFieldModel.fieldName] = eruptFieldModel.eruptFieldJson.edit.$value;
         }
+        return result;
     }
 
     load(open) {
@@ -98,28 +93,12 @@ export class ChoiceComponent implements OnInit {
         if (open) {
             if (choiceType.anewFetch) {
                 this.isLoading = true;
-                this.dataService.findChoiceItem(this.eruptModel.eruptName, this.eruptField.fieldName, this.eruptParentName).subscribe(data => {
+                this.dataService.findChoiceItemFilter(this.eruptModel.eruptName, this.eruptField.fieldName, this.getFromData(), this.eruptParentName).subscribe(data => {
                     this.eruptField.componentValue = data;
+                    this.choiceVL = data;
                     this.isLoading = false;
-                });
+                })
             }
-            if (this.dependLinkage && choiceType.dependField) {
-                for (let eruptFieldModel of this.eruptModel.eruptFieldModels) {
-                    if (eruptFieldModel.fieldName == choiceType.dependField) {
-                        let dependValue = eruptFieldModel.eruptFieldJson.edit.$value;
-                        if (null === dependValue || "" === dependValue || undefined === dependValue) {
-                            this.msg.warning(this.i18n.fanyi("global.pre_select") + eruptFieldModel.eruptFieldJson.edit.title)
-                            this.choiceVL = [];
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    changeTagAll($event) {
-        for (let vl of this.eruptField.componentValue) {
-            vl.$viewValue = $event;
         }
     }
 

--- a/src/app/build/erupt/components/choice/choice.component.ts
+++ b/src/app/build/erupt/components/choice/choice.component.ts
@@ -44,9 +44,15 @@ export class ChoiceComponent implements OnInit {
         if (this.eruptField.eruptFieldJson.edit.choiceType.dependField) {
             this.eruptModel.eruptFieldModelMap.get(this.eruptField.eruptFieldJson.edit.choiceType.dependField).eruptFieldJson.edit.$valueSubject?.asObservable().subscribe(val => {
                 let choiceType = this.eruptField.eruptFieldJson.edit.choiceType;
+                let clean = () => {
+                    if (this.choiceVL.filter(it => it.value == this.eruptField.eruptFieldJson.edit.$value).length == 0) {
+                        this.eruptField.eruptFieldJson.edit.$value = null;
+                    }
+                }
                 if (choiceType.dependExpr == '') {
                     this.dataService.findChoiceItemFilter(this.eruptModel.eruptName, this.eruptField.fieldName, this.getFromData(), this.eruptParentName).subscribe(data => {
                         this.choiceVL = data;
+                        clean();
                     })
                 } else {
                     this.choiceVL = this.eruptField.componentValue.filter(vl => {
@@ -54,12 +60,12 @@ export class ChoiceComponent implements OnInit {
                             return eval(choiceType.dependExpr);
                         } catch (e) {
                             this.msg.error(e);
+                        } finally {
+                            clean();
                         }
                     })
                 }
-                if (this.choiceVL.filter(it => it.value == this.eruptField.eruptFieldJson.edit.$value).length == 0) {
-                    this.eruptField.eruptFieldJson.edit.$value = null;
-                }
+
             })
         } else {
             this.choiceVL = this.eruptField.componentValue

--- a/src/app/build/erupt/components/date/date.component.ts
+++ b/src/app/build/erupt/components/date/date.component.ts
@@ -44,6 +44,7 @@ export class DateComponent implements OnInit {
         this.endToday = moment(moment().format("yyyy-MM-DD 23:59:59")).toDate();
         this.dateRanges = <any>{
             [this.i18n.fanyi("global.today")]: [this.datePipe.transform(new Date(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
+            [this.i18n.fanyi("global.yesterday")]: [this.datePipe.transform(moment().add(-1, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(moment().add(-1, 'day').toDate(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.last_7_day")]: [this.datePipe.transform(moment().add(-7, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.last_30_day")]: [this.datePipe.transform(moment().add(-30, 'day').toDate(), "yyyy-MM-dd 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],
             [this.i18n.fanyi("global.date.this_month")]: [this.datePipe.transform(moment().toDate(), "yyyy-MM-01 00:00:00"), this.datePipe.transform(new Date(), "yyyy-MM-dd 23:59:59")],

--- a/src/app/build/erupt/components/edit-type/edit-type.component.html
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.html
@@ -192,7 +192,7 @@
                                     [optionalHelp]="field.eruptFieldJson.edit.desc">
                                     <erupt-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
                                                   [eruptParentName]="parentEruptName" [editType]="this"
-                                                  [readonly]="isReadonly(field)" #choice>
+                                                  [readonly]="isReadonly(field)">
 
                                     </erupt-choice>
                                 </se>
@@ -220,6 +220,7 @@
                                     [required]="field.eruptFieldJson.edit.notNull"
                                     [optionalHelp]="field.eruptFieldJson.edit.desc">
                                     <erupt-multi-choice [eruptModel]="eruptModel" [eruptField]="field" [size]="size"
+                                                        [eruptParentName]="parentEruptName"
                                                         [readonly]="isReadonly(field)">
 
                                     </erupt-multi-choice>

--- a/src/app/build/erupt/components/edit-type/edit-type.component.ts
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.ts
@@ -1,4 +1,4 @@
-import {Component, DoCheck, Inject, Input, OnDestroy, OnInit, QueryList, ViewChildren} from "@angular/core";
+import {Component, DoCheck, Inject, Input, KeyValueDiffers, OnDestroy, OnInit} from "@angular/core";
 import {EruptFieldModel} from "../../model/erupt-field.model";
 import {
     AttachmentEnum,
@@ -21,7 +21,7 @@ import {NzModalService} from "ng-zorro-antd/modal";
 import {NzMessageService} from "ng-zorro-antd/message";
 import {NzUploadFile} from "ng-zorro-antd/upload/interface";
 import {DataHandlerService} from "../../service/data-handler.service";
-import {ChoiceComponent} from "../choice/choice.component";
+import {BehaviorSubject} from "rxjs";
 
 @Component({
     selector: "erupt-edit-type",
@@ -51,8 +51,6 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
 
     @Input() readonly: boolean = false;
 
-    @ViewChildren('choice') choices: QueryList<ChoiceComponent>;
-
     private showByFieldModels: EruptFieldModel[];
 
     eruptModel: EruptModel;
@@ -75,6 +73,7 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
 
     constructor(public dataService: DataService,
                 private i18n: I18NService,
+                private differs: KeyValueDiffers,
                 private dataHandlerService: DataHandlerService,
                 @Inject(DA_SERVICE_TOKEN) public tokenService: ITokenService,
                 @Inject(NzModalService) private modal: NzModalService,
@@ -89,6 +88,8 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
             this.col = colRules[1];
         }
         for (let model of this.eruptModel.eruptFieldModels) {
+            model.eruptFieldJson.edit.$valueDiff = this.differs.find(model.eruptFieldJson.edit).create();
+            model.eruptFieldJson.edit.$valueSubject = new BehaviorSubject<any>(null);
             let edit = model.eruptFieldJson.edit;
             if (edit.type == EditType.ATTACHMENT) {
                 if (!edit.$viewValue) {
@@ -119,6 +120,11 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
     }
 
     ngDoCheck() {
+        for (let eruptFieldModel of this.eruptModel.eruptFieldModels) {
+            if (eruptFieldModel.eruptFieldJson.edit.$valueDiff.diff(eruptFieldModel.eruptFieldJson.edit)) {
+                eruptFieldModel.eruptFieldJson.edit.$valueSubject.next(eruptFieldModel.eruptFieldJson.edit.$value);
+            }
+        }
         if (this.showByFieldModels) {
             for (let model of this.showByFieldModels) {
                 let showBy = model.eruptFieldJson.edit.showBy;
@@ -129,15 +135,6 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
                         this.showByCheck(m);
                     });
                 }
-            }
-        }
-        if (this.choices && this.choices.length > 0) {
-            for (let choice of this.choices) {
-                this.dataHandlerService.eruptFieldModelChangeHook(this.eruptModel, choice.eruptField, (value) => {
-                    for (let choice of this.choices) {
-                        choice.dependChange(value);
-                    }
-                });
             }
         }
     }

--- a/src/app/build/erupt/components/edit-type/edit-type.component.ts
+++ b/src/app/build/erupt/components/edit-type/edit-type.component.ts
@@ -142,7 +142,11 @@ export class EditTypeComponent implements OnInit, OnDestroy, DoCheck {
     showByCheck(model: EruptFieldModel) {
         let showBy = model.eruptFieldJson.edit.showBy;
         let value = this.eruptModel.eruptFieldModelMap.get(showBy.dependField).eruptFieldJson.edit.$value;
-        model.eruptFieldJson.edit.show = !!eval(showBy.expr);
+        try {
+            model.eruptFieldJson.edit.show = !!eval(showBy.expr);
+        } catch (e) {
+            console.error(model.fieldName + " showBy expr err: " + e)
+        }
     }
 
     ngOnDestroy(): void {

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {MultiChoiceEnum} from "../../model/erupt.enum";
 import {EruptModel} from "../../model/erupt.model";
-import {EruptFieldModel, VL} from "../../model/erupt-field.model";
+import {EruptFieldModel} from "../../model/erupt-field.model";
 import {DataService} from "@shared/service/data.service";
 
 @Component({
@@ -33,10 +33,17 @@ export class MultiChoiceComponent implements OnInit {
                 .eruptFieldJson.edit.$valueSubject?.asObservable().subscribe(val => {
                 this.dataService.findChoiceItemFilter(this.eruptModel.eruptName, this.eruptField.fieldName, this.getFromData(), this.eruptParentName).subscribe(data => {
                     this.eruptField.componentValue = data;
+                    if (this.eruptField.eruptFieldJson.edit.$value) {
+                        this.eruptField.eruptFieldJson.edit.$value = this.eruptField.eruptFieldJson.edit.$value.filter((value) => {
+                            return this.eruptField.componentValue.some(cv => cv.value == String(value));
+                        })
+
+                        //
+                        // if (this.eruptField.componentValue.filter((it: VL) => this.eruptField.eruptFieldJson.edit.$value?.some(value => String(value) === it.value)).length == 0) {
+                        //     this.eruptField.eruptFieldJson.edit.$value = [];
+                        // }
+                    }
                 })
-                if (this.eruptField.componentValue.filter((it: VL) => this.eruptField.eruptFieldJson.edit.$value?.some(value => String(value) === it.value)).length == 0) {
-                    this.eruptField.eruptFieldJson.edit.$value = [];
-                }
             })
         }
     }

--- a/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
+++ b/src/app/build/erupt/components/multi-choice/multi-choice.component.ts
@@ -1,14 +1,15 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {MultiChoiceEnum} from "../../model/erupt.enum";
 import {EruptModel} from "../../model/erupt.model";
-import {EruptFieldModel} from "../../model/erupt-field.model";
+import {EruptFieldModel, VL} from "../../model/erupt-field.model";
+import {DataService} from "@shared/service/data.service";
 
 @Component({
     selector: 'erupt-multi-choice',
     templateUrl: './multi-choice.component.html',
     styleUrls: ['./multi-choice.component.less']
 })
-export class MultiChoiceComponent  {
+export class MultiChoiceComponent implements OnInit {
 
     @Input() eruptModel: EruptModel;
 
@@ -18,9 +19,38 @@ export class MultiChoiceComponent  {
 
     @Input() size: 'large' | 'small' | "default" = "default";
 
+    @Input() eruptParentName: string;
+
     multiChoiceEnum = MultiChoiceEnum;
 
-    isNumeric(str:string): boolean {
+    constructor(private dataService: DataService) {
+
+    }
+
+    ngOnInit(): void {
+        if (this.eruptField.eruptFieldJson.edit.multiChoiceType.dependField) {
+            this.eruptModel.eruptFieldModelMap.get(this.eruptField.eruptFieldJson.edit.multiChoiceType.dependField)
+                .eruptFieldJson.edit.$valueSubject?.asObservable().subscribe(val => {
+                this.dataService.findChoiceItemFilter(this.eruptModel.eruptName, this.eruptField.fieldName, this.getFromData(), this.eruptParentName).subscribe(data => {
+                    this.eruptField.componentValue = data;
+                })
+                if (this.eruptField.componentValue.filter((it: VL) => this.eruptField.eruptFieldJson.edit.$value?.some(value => String(value) === it.value)).length == 0) {
+                    this.eruptField.eruptFieldJson.edit.$value = [];
+                }
+            })
+        }
+    }
+
+
+    getFromData(): any {
+        let result = {};
+        for (let eruptFieldModel of this.eruptModel.eruptFieldModels) {
+            result[eruptFieldModel.fieldName] = eruptFieldModel.eruptFieldJson.edit.$value;
+        }
+        return result;
+    }
+
+    isNumeric(str: string): boolean {
         return !isNaN(parseFloat(str)) && isFinite(parseFloat(str));
     }
 
@@ -36,4 +66,5 @@ export class MultiChoiceComponent  {
     }
 
     protected readonly parseInt = parseInt;
+
 }

--- a/src/app/build/erupt/components/search/search.component.html
+++ b/src/app/build/erupt/components/search/search.component.html
@@ -75,9 +75,7 @@
                         <ng-container *ngIf="field.eruptFieldJson.edit.search.vague">
                             <div nz-col [nzXs]="24">
                                 <erupt-search-se [field]="field">
-                                    <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field" [size]="size"
-                                                  [vagueSearch]="true" [checkAll]="true" #choice
-                                                  [dependLinkage]="false">
+                                    <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field" [size]="size" [vagueSearch]="true" [checkAll]="true">
 
                                     </erupt-choice>
                                 </erupt-search-se>
@@ -88,8 +86,7 @@
                                 <ng-container *ngSwitchCase="choiceEnum.RADIO">
                                     <div nz-col [nzXs]="24">
                                         <erupt-search-se [field]="field">
-                                            <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field"
-                                                          [size]="size" #choice [dependLinkage]="false">
+                                            <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field" [size]="size" >
 
                                             </erupt-choice>
                                         </erupt-search-se>
@@ -101,8 +98,7 @@
                                          [nzXl]="col.xl"
                                          [nzXXl]="col.xxl">
                                         <erupt-search-se [field]="field">
-                                            <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field"
-                                                          [size]="size" [dependLinkage]="false" #choice>
+                                            <erupt-choice [eruptModel]="searchEruptModel" [eruptField]="field" [size]="size">
 
                                             </erupt-choice>
                                         </erupt-search-se>

--- a/src/app/build/erupt/components/search/search.component.ts
+++ b/src/app/build/erupt/components/search/search.component.ts
@@ -1,16 +1,26 @@
-import {Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChildren} from '@angular/core';
+import {
+    Component,
+    DoCheck,
+    EventEmitter,
+    Input,
+    KeyValueDiffers,
+    OnInit,
+    Output,
+    QueryList,
+    ViewChildren
+} from '@angular/core';
 import {EruptModel} from "../../model/erupt.model";
-import {ChoiceEnum, DateEnum, EditType} from "../../model/erupt.enum";
+import {ChoiceEnum, EditType} from "../../model/erupt.enum";
 import {colRules} from "@shared/model/util.model";
-import {DataHandlerService} from "../../service/data-handler.service";
 import {ChoiceComponent} from "../choice/choice.component";
+import {BehaviorSubject} from "rxjs";
 
 @Component({
     selector: 'erupt-search',
     templateUrl: './search.component.html',
     styleUrls: ['./search.component.less']
 })
-export class SearchComponent implements OnInit {
+export class SearchComponent implements OnInit, DoCheck {
 
     @Input() searchEruptModel: EruptModel;
 
@@ -27,26 +37,23 @@ export class SearchComponent implements OnInit {
 
     choiceEnum = ChoiceEnum;
 
-    dateEnum = DateEnum;
 
-
-    constructor(private dataHandlerService: DataHandlerService) {
+    constructor(private differs: KeyValueDiffers,) {
     }
 
-    // ngDoCheck(): void {
-    //     if (this.choices && this.choices.length > 0) {
-    //         for (let choice of this.choices) {
-    //             this.dataHandlerService.eruptFieldModelChangeHook(this.searchEruptModel, choice.eruptField, (value) => {
-    //                 for (let choice of this.choices) {
-    //                     choice.dependChange(value);
-    //                 }
-    //             });
-    //         }
-    //     }
-    // }
+    ngDoCheck(): void {
+        for (let eruptFieldModel of this.searchEruptModel.eruptFieldModels) {
+            if (eruptFieldModel.eruptFieldJson.edit.$valueDiff.diff(eruptFieldModel.eruptFieldJson.edit)) {
+                eruptFieldModel.eruptFieldJson.edit.$valueSubject.next(eruptFieldModel.eruptFieldJson.edit.$value);
+            }
+        }
+    }
 
     ngOnInit(): void {
-
+        for (let model of this.searchEruptModel.eruptFieldModels) {
+            model.eruptFieldJson.edit.$valueDiff = this.differs.find(model.eruptFieldJson.edit).create();
+            model.eruptFieldJson.edit.$valueSubject = new BehaviorSubject<any>(null);
+        }
     }
 
     enterEvent(event) {

--- a/src/app/build/erupt/model/erupt-field.model.ts
+++ b/src/app/build/erupt/model/erupt-field.model.ts
@@ -9,6 +9,8 @@ import {
     TabEnum,
     ViewType
 } from "./erupt.enum";
+import {KeyValueDiffer} from "@angular/core";
+import {Subject} from "rxjs";
 
 
 export interface EruptFieldModel {
@@ -96,7 +98,11 @@ export interface Edit {
     codeEditType?: CodeEditType;
     mapType?: MapType;
     $tabTreeViewData?: any;
+
+    $valueDiff?: KeyValueDiffer<any, any>;
+    $valueSubject?: Subject<any>
     $value?: any;
+
     $viewValue?: any;
     $tempValue?: any;
     $beforeValue?: any;
@@ -183,6 +189,7 @@ interface ChoiceType {
 
 interface MultiChoiceType {
     type: MultiChoiceEnum;
+    dependField: string;
 }
 
 interface TagsType {
@@ -232,5 +239,4 @@ export interface VL {
     label: string;
     desc: string;
     disable: boolean;
-    $viewValue?: any;
 }

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -51,7 +51,8 @@ interface Layout {
     pageSize: number;
     pageSizes: number[];
     refreshTime: number;
-    tableWidth: number;
+    tableWidth: string;
+    tableOperatorWidth: string;
 }
 
 

--- a/src/app/build/erupt/model/erupt.model.ts
+++ b/src/app/build/erupt/model/erupt.model.ts
@@ -51,6 +51,7 @@ interface Layout {
     pageSize: number;
     pageSizes: number[];
     refreshTime: number;
+    tableWidth: number;
 }
 
 

--- a/src/app/build/erupt/service/data-handler.service.ts
+++ b/src/app/build/erupt/service/data-handler.service.ts
@@ -163,15 +163,6 @@ export class DataHandlerService {
             if (edit.search.value) {
                 if (edit.search.vague) {
                     switch (edit.type) {
-                        case EditType.CHOICE:
-                            let arr = [];
-                            for (let vl of field.componentValue) {
-                                if (vl.$viewValue) {
-                                    arr.push(vl.value);
-                                }
-                            }
-                            obj[field.fieldName] = arr;
-                            break;
                         case EditType.NUMBER:
                             if ((edit.$l_val || edit.$l_val === 0) && (edit.$r_val || edit.$r_val === 0)) {
                                 obj[field.fieldName] = [edit.$l_val, edit.$r_val];
@@ -582,24 +573,6 @@ export class DataHandlerService {
             this.emptyEruptValue({
                 eruptModel: eruptBuildModel.combineErupts[key]
             });
-        }
-    }
-
-    /**
-     * eruptModel value值数据变换触发钩子
-     */
-    eruptFieldModelChangeHook(eruptModel: EruptModel, field: EruptFieldModel, callback: Function) {
-        let edit = field.eruptFieldJson.edit;
-        if (edit.type == EditType.CHOICE && edit.choiceType.dependField) {
-            let depField = eruptModel.eruptFieldModelMap.get(edit.choiceType.dependField);
-            if (depField) {
-                let depEdit = depField.eruptFieldJson.edit;
-                if (depEdit.$beforeValue != depEdit.$value) {
-                    callback(depEdit.$value)
-                    null != depEdit.$beforeValue && (edit.$value = null);
-                    depEdit.$beforeValue = depEdit.$value;
-                }
-            }
         }
     }
 

--- a/src/app/build/erupt/view/table/table.component.html
+++ b/src/app/build/erupt/view/table/table.component.html
@@ -75,17 +75,20 @@
                                 </ng-container>
                             </ng-container>
                             <ng-container *ngIf="existMultiRowFoldButtons">
-                                <button nz-button nz-dropdown [nzDropdownMenu]="moreButtons" nzPlacement="bottomRight" style="margin-right: 8px;margin-left: 0" class="mb-sm">
+                                <button nz-button nz-dropdown [nzDropdownMenu]="moreButtons" nzPlacement="bottomRight"
+                                        style="margin-right: 8px;margin-left: 0" class="mb-sm">
                                     <i nz-icon nzType="ellipsis"></i>
                                 </button>
                                 <nz-dropdown-menu #moreButtons="nzDropdownMenu">
                                     <ul nz-menu>
-                                        <ng-container *ngFor="let item of eruptBuildModel.eruptModel.eruptJson.rowOperation">
+                                        <ng-container
+                                            *ngFor="let item of eruptBuildModel.eruptModel.eruptJson.rowOperation">
                                             <ng-container *ngIf="item.mode != operationMode.SINGLE">
                                                 <ng-container *ngIf="item.fold">
                                                     <li nz-menu-item [nz-tooltip]="item.tip"
                                                         (click)="createOperator(item)">
-                                                        <i *ngIf="item.icon" class="fa" [ngClass]="item.icon" style="margin-right: 8px"></i>
+                                                        <i *ngIf="item.icon" class="fa" [ngClass]="item.icon"
+                                                           style="margin-right: 8px"></i>
                                                         <span>{{ item.title }}</span>
                                                     </li>
                                                 </ng-container>
@@ -152,7 +155,7 @@
                         [body]="bodyTpl" [data]="dataPage.data" [columns]="columns"
                         [virtualScroll]="dataPage.data.length >= 100"
                         [virtualItemSize]="47"
-                        [scroll]="{x: (clientWidth > 768 ? showColumnLength * 160 : 0) + 'px', y: (clientHeight > 814 ? 525 + (clientHeight - 814) : 525) + 'px'}"
+                        [scroll]="{x: (clientWidth > 768 ? tableWidth : '0px'), y: (clientHeight > 814 ? 525 + (clientHeight - 814) : 525) + 'px'}"
                         (change)="tableDataChange($event)" [bordered]="settingSrv.layout['bordered']"
                         [page]="dataPage.page" [size]="'middle'"
                     >

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -593,7 +593,7 @@ export class TableComponent implements OnInit, OnDestroy {
             eruptJson.rowOperation.forEach(ro => {
                 if (ro.mode !== OperationMode.BUTTON && ro.mode !== OperationMode.MULTI_ONLY) {
                     ro.fold && children.push({
-                        text: ro.title,
+                        text: (ro.icon && `<i class=\"${ro.icon}\"></i> &nbsp;`) + ro.title,
                         iifBehavior: 'disabled',
                         tooltip: ro.tip,
                         iif: (item) => exprEval(ro.ifExpr, item),
@@ -603,7 +603,7 @@ export class TableComponent implements OnInit, OnDestroy {
             });
             eruptJson.drills.forEach(drill => {
                 drill.fold && children.push({
-                    text: drill.title,
+                    text: (drill.icon && `<i class=\"${drill.icon}\"></i> &nbsp;`) + drill.title,
                     iifBehavior: 'disabled',
                     // tooltip: drill.title,
                     click: (record) => createDrillModel(drill, record[eruptJson.primaryKeyCol])

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -92,8 +92,6 @@ export class TableComponent implements OnInit, OnDestroy {
 
     columns: STColumn[];
 
-    showColumnLength: number;
-
     linkTree: boolean = false;
 
     showTable: boolean = true;
@@ -138,6 +136,8 @@ export class TableComponent implements OnInit, OnDestroy {
     refreshTimeInterval: any;
 
     existMultiRowFoldButtons: boolean = false;
+
+    tableWidth: string;
 
     @Input() set drill(drill: DrillInput) {
         this._drill = drill;
@@ -615,6 +615,8 @@ export class TableComponent implements OnInit, OnDestroy {
             });
         }
         if (tableOperators.length > 0) {
+            console.log(tableOperators.length * 35 + 18 + (isFoldButtons ? 60 : 0))
+            console.log(tableOperators)
             _columns.push({
                 title: this.i18n.fanyi("table.operation"),
                 fixed: "right",
@@ -625,7 +627,11 @@ export class TableComponent implements OnInit, OnDestroy {
             });
         }
         this.columns = _columns;
-        this.showColumnLength = this.eruptBuildModel.eruptModel.tableColumns.filter(e => e.show).length;
+        if (eruptJson.layout.tableWidth && eruptJson.layout.tableWidth > 0) {
+            this.tableWidth = eruptJson.layout.tableWidth + "px";
+        } else {
+            this.tableWidth = (this.eruptBuildModel.eruptModel.tableColumns.filter(e => e.show).length * 160) + "px"
+        }
     }
 
 

--- a/src/app/build/erupt/view/table/table.component.ts
+++ b/src/app/build/erupt/view/table/table.component.ts
@@ -615,20 +615,18 @@ export class TableComponent implements OnInit, OnDestroy {
             });
         }
         if (tableOperators.length > 0) {
-            console.log(tableOperators.length * 35 + 18 + (isFoldButtons ? 60 : 0))
-            console.log(tableOperators)
             _columns.push({
                 title: this.i18n.fanyi("table.operation"),
                 fixed: "right",
-                width: tableOperators.length * 35 + 18 + (isFoldButtons ? 60 : 0),
+                width: eruptJson.layout.tableOperatorWidth ? eruptJson.layout.tableOperatorWidth : (tableOperators.length * 35 + 18 + (isFoldButtons ? 60 : 0)),
                 className: "text-center",
                 buttons: tableOperators,
                 resizable: false
             });
         }
         this.columns = _columns;
-        if (eruptJson.layout.tableWidth && eruptJson.layout.tableWidth > 0) {
-            this.tableWidth = eruptJson.layout.tableWidth + "px";
+        if (eruptJson.layout.tableWidth) {
+            this.tableWidth = eruptJson.layout.tableWidth;
         } else {
             this.tableWidth = (this.eruptBuildModel.eruptModel.tableColumns.filter(e => e.show).length * 160) + "px"
         }

--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -43,7 +43,6 @@ import {
     zh_CN as zorroZhCN,
     zh_TW as zorroZhTW
 } from 'ng-zorro-antd/i18n';
-import {HttpClient} from "@angular/common/http";
 import {EruptAppData} from "@shared/model/erupt-app.model";
 
 interface LangConfigData {
@@ -129,7 +128,7 @@ for (let key in LANGS) {
 
 
 @Injectable()
-export class I18NService implements OnInit{
+export class I18NService implements OnInit {
 
     currentLang: string;
 
@@ -173,11 +172,42 @@ export class I18NService implements OnInit{
                     }
                 }
                 allRows.forEach(it => {
-                    let row = it.split(',');
+                    let row = parseCSVRow(it);
                     langMapping[row[0]] = row[index];
                 })
                 this.langMapping = langMapping;
                 success();
+            }
+
+            function parseCSVRow(row): any[] {
+                let result = [];
+                let field = '';
+                let inQuotes = false;
+                let escapeNext = false;
+
+                for (let i = 0; i < row.length; i++) {
+                    let char = row[i];
+
+                    if (escapeNext) {
+                        field += char;
+                        escapeNext = false;
+                    } else if (char === '"') {
+                        inQuotes = !inQuotes;
+                    } else if (char === ',' && !inQuotes) {
+                        result.push(field);
+                        field = '';
+                    } else if (char === '\\') {
+                        escapeNext = true;
+                    } else {
+                        field += char;
+                    }
+                }
+
+                if (field.length > 0) {
+                    result.push(field);
+                }
+
+                return result;
             }
         };
 

--- a/src/app/core/net/default.interceptor.ts
+++ b/src/app/core/net/default.interceptor.ts
@@ -202,8 +202,8 @@ export class DefaultInterceptor implements HttpInterceptor {
                     });
                 } else {
                     this.modal.error({
-                        nzTitle: 'Error',
-                        nzContent: event.error.message
+                        nzTitle: event.error.message,
+                        // nzContent: event.error.message
                     });
                     Object.assign(event, {
                         status: 200, ok: true, body: {
@@ -214,7 +214,7 @@ export class DefaultInterceptor implements HttpInterceptor {
                 return of(new HttpResponse(event));
             default:
                 if (event instanceof HttpErrorResponse) {
-                    console.warn("未可知错误，大部分是由于后端无响应或无效配置引起", event);
+                    console.warn("Unknown errors, mostly due to unresponsive backend or invalid configuration", event);
                     this.msg.error(event.message);
                 }
                 break;

--- a/src/app/layout/erupt/erupt.component.html
+++ b/src/app/layout/erupt/erupt.component.html
@@ -10,7 +10,7 @@
         <router-outlet></router-outlet>
     </section>
 </nz-water-mark>
-<theme-btn [devTips]="null" [types]="themes"></theme-btn>
+<theme-btn cdkDrag [devTips]="null" [types]="themes"></theme-btn>
 <nz-back-top></nz-back-top>
 <ng-template #settingHost></ng-template>
 <footer class="licence">Powered by Erupt © 2018 - {{nowYear}}</footer>

--- a/src/app/layout/erupt/header/components/user.component.ts
+++ b/src/app/layout/erupt/header/components/user.component.ts
@@ -4,7 +4,7 @@ import {SettingsService} from "@delon/theme";
 import {DA_SERVICE_TOKEN, ITokenService} from "@delon/auth";
 import {DataService} from "@shared/service/data.service";
 import {I18NService} from "@core";
-import {WindowModel} from "@shared/model/window.model";
+import {UserTool, WindowModel} from "@shared/model/window.model";
 import {NzModalService} from "ng-zorro-antd/modal";
 import {ResetPwdComponent} from "../../../../routes/reset-pwd/reset-pwd.component";
 import {EruptAppData} from "@shared/model/erupt-app.model";
@@ -25,6 +25,12 @@ import {SocketService} from "@shared/service/socket.service";
                 <div *ngIf="settings.user['tenantName']" style="padding: 8px 12px;border-bottom:1px solid #eee">
                     {{ settings.user['tenantName'] }}
                 </div>
+                <ng-container *ngIf="userTools">
+                    <div nz-menu-item *ngFor="let tool of userTools" (click)="tool.click($event)">
+                        <i *ngIf="tool.icon" [ngClass]="tool.icon" class="mr-sm"></i>
+                        <span [innerHTML]="tool.text | safeHtml"></span>
+                    </div>
+                </ng-container>
                 <div nz-menu-item (click)="changePwd()" *ngIf="resetPassword">
                     <i nz-icon nzType="edit" nzTheme="fill" class="mr-sm"></i>{{ 'global.reset_pwd'|translate }}
                 </div>
@@ -38,6 +44,8 @@ import {SocketService} from "@shared/service/socket.service";
 export class HeaderUserComponent {
 
     resetPassword = EruptAppData.get().resetPwd;
+
+    userTools: UserTool[] = WindowModel.userTools;
 
     constructor(
         public settings: SettingsService,

--- a/src/app/layout/erupt/header/header.component.html
+++ b/src/app/layout/erupt/header/header.component.html
@@ -35,7 +35,7 @@
             <li (click)="customToolsFun($event,r)" [ngClass]="r.mobileHidden?'hidden-mobile':''">
                 <div class="alain-default__nav-item" [title]="r.text">
                     <i *ngIf="r.icon" class="fa {{r.icon}}"></i>
-                    <div *ngIf="r.render" [innerHTML]="r.render | safeHtml"></div>
+                    <div *ngIf="r.render" [innerHTML]="renderTool(r) | safeHtml"></div>
                 </div>
             </li>&nbsp;
         </ng-container>

--- a/src/app/layout/erupt/header/header.component.html
+++ b/src/app/layout/erupt/header/header.component.html
@@ -1,6 +1,7 @@
 <div class="alain-default__header-logo" ripper color="#000">
     <a [routerLink]="settings.user['indexPath']" (click)="toIndex()" class="header-link" style="user-select:none">
-        <img *ngIf="logoPath" [src]="logoPath" class="header-logo-img" alt=""/>
+        <img *ngIf="!settings.layout.collapsed && logoPath" [src]="logoPath" class="header-logo-img" alt=""/>
+        <img *ngIf="settings.layout.collapsed && logoFoldPath" [src]="logoFoldPath" class="header-logo-img" alt=""/>
         <span *ngIf="logoText" class="header-logo-text hidden-mobile">{{ logoText }}</span>
     </a>
 </div>
@@ -33,7 +34,8 @@
         <ng-container *ngFor="let r of r_tools">
             <li (click)="customToolsFun($event,r)" [ngClass]="r.mobileHidden?'hidden-mobile':''">
                 <div class="alain-default__nav-item" [title]="r.text">
-                    <i class="fa {{r.icon}}"></i>
+                    <i *ngIf="r.icon" class="fa {{r.icon}}"></i>
+                    <div *ngIf="r.render" [innerHTML]="r.render | safeHtml"></div>
                 </div>
             </li>&nbsp;
         </ng-container>

--- a/src/app/layout/erupt/header/header.component.html
+++ b/src/app/layout/erupt/header/header.component.html
@@ -1,7 +1,7 @@
 <div class="alain-default__header-logo" ripper color="#000">
     <a [routerLink]="settings.user['indexPath']" (click)="toIndex()" class="header-link" style="user-select:none">
         <img *ngIf="logoPath" [src]="logoPath" class="header-logo-img" alt=""/>
-        <span *ngIf="logoText" class="header-logo-text hidden-mobile">{{logoText}}</span>
+        <span *ngIf="logoText" class="header-logo-text hidden-mobile">{{ logoText }}</span>
     </a>
 </div>
 
@@ -76,6 +76,11 @@
                     </erupt-settings>
                 </ng-container>
             </nz-drawer>
+        </li>
+        <li *ngIf="isEruptAi">
+            <div class="alain-default__nav-item" (click)="openEruptAi()">
+                <i class="fa fa-magic" aria-hidden="true"></i>
+            </div>
         </li>
 
         <li>

--- a/src/app/layout/erupt/header/header.component.less
+++ b/src/app/layout/erupt/header/header.component.less
@@ -1,4 +1,14 @@
 :host {
+    .alain-default__nav {
+        .alain-default__nav-item {
+            transition: all 300ms;
+
+            &:hover {
+                background: rgba(82, 82, 82, 0.1);
+            }
+        }
+    }
+
     ::ng-deep {
         .header-logo {
             padding: 0 12px;
@@ -73,7 +83,6 @@
                 }
             }
         }
-
     }
 }
 

--- a/src/app/layout/erupt/header/header.component.ts
+++ b/src/app/layout/erupt/header/header.component.ts
@@ -82,6 +82,14 @@ export class HeaderComponent implements OnInit {
         }
     }
 
+    renderTool(tool: CustomerTool): string {
+        if (typeof tool.render == 'function') {
+            return tool.render();
+        } else {
+            return tool.render;
+        }
+    }
+
     openEruptAi() {
         let model = this.modal.create({
             nzWrapClassName: "modal-lg",

--- a/src/app/layout/erupt/header/header.component.ts
+++ b/src/app/layout/erupt/header/header.component.ts
@@ -10,6 +10,8 @@ import {AppViewService} from "@shared/service/app-view.service";
 import {EruptAppData} from "@shared/model/erupt-app.model";
 import {EruptTenantInfoData} from "../../../build/erupt/model/erupt-tenant";
 import {DataService} from "@shared/service/data.service";
+import {EruptIframeComponent} from "@shared/component/iframe.component";
+import {DA_SERVICE_TOKEN, TokenService} from "@delon/auth";
 
 @Component({
     selector: "layout-header",
@@ -42,6 +44,10 @@ export class HeaderComponent implements OnInit {
 
     tenantDomainInfo = EruptTenantInfoData.get();
 
+    get isEruptAi(): boolean {
+        return EruptAppData.get().properties["erupt-ai"];
+    }
+
     openDrawer() {
         this.drawerVisible = true;
     }
@@ -53,6 +59,7 @@ export class HeaderComponent implements OnInit {
     constructor(public settings: SettingsService,
                 private router: Router,
                 private appViewService: AppViewService,
+                @Inject(DA_SERVICE_TOKEN) private tokenService: TokenService,
                 @Inject(NzModalService) private modal: NzModalService) {
         if (this.tenantDomainInfo) {
             if (this.tenantDomainInfo.logo) {
@@ -71,6 +78,26 @@ export class HeaderComponent implements OnInit {
         if (EruptAppData.get().locales.length <= 1) {
             this.showI18n = false;
         }
+    }
+
+    openEruptAi() {
+        let model = this.modal.create({
+            nzWrapClassName: "modal-lg",
+            nzMaskClosable: false,
+            nzKeyboard: true,
+            nzFooter: null,
+            nzClosable: true,
+            nzTitle: "AI 交互",
+            nzStyle: {
+                top: '30px',
+            },
+            nzBodyStyle: {
+                padding: "0"
+            },
+            nzContent: EruptIframeComponent,
+        });
+        model.getContentComponent().url = "ai-chat.html?_token=" + this.tokenService.get().token;
+        model.getContentComponent().height = "83vh"
     }
 
     toggleCollapsedSidebar() {

--- a/src/app/layout/erupt/header/header.component.ts
+++ b/src/app/layout/erupt/header/header.component.ts
@@ -32,6 +32,8 @@ export class HeaderComponent implements OnInit {
 
     logoPath: string = WindowModel.logoPath;
 
+    logoFoldPath: string = WindowModel.logoFoldPath;
+
     logoText: string = WindowModel.logoText;
 
     r_tools: CustomerTool[] = WindowModel.r_tools;

--- a/src/app/layout/layout.module.ts
+++ b/src/app/layout/layout.module.ts
@@ -19,6 +19,7 @@ import {NzGridModule} from 'ng-zorro-antd/grid';
 import {NzIconModule} from 'ng-zorro-antd/icon';
 import {NzInputModule} from 'ng-zorro-antd/input';
 import {NzSpinModule} from 'ng-zorro-antd/spin';
+import {DragDropModule} from '@angular/cdk/drag-drop';
 
 // eslint-disable-next-line import/order
 import {LayoutBlankComponent} from './blank/blank.component';
@@ -92,7 +93,8 @@ const PASSPORT = [LayoutPassportComponent];
         NzBackTopModule,
         ReuseTabModule,
         NzBreadCrumbModule,
-        NzWaterMarkModule
+        NzWaterMarkModule,
+        DragDropModule
     ],
     declarations: [...COMPONENTS, ...HEADER_COMPONENTS, ...PASSPORT, MenuComponent],
     exports: [...COMPONENTS, ...PASSPORT]

--- a/src/app/shared/model/window.model.ts
+++ b/src/app/shared/model/window.model.ts
@@ -6,8 +6,6 @@ export class WindowModel {
 
     public static fileDomain: string = WindowModel.config["fileDomain"] || undefined;
 
-    public static r_tools: CustomerTool[];
-
     public static amapKey: string;
 
     public static amapSecurityJsCode: string;
@@ -30,10 +28,15 @@ export class WindowModel {
 
     public static copyrightTxt: any; //授权文本
 
+    public static r_tools: CustomerTool[];
+
+    public static userTools: UserTool[];
+
     public static upload: Function;
 
     public static init() {
         WindowModel.r_tools = WindowModel.config["r_tools"] || [];
+        WindowModel.userTools = WindowModel.config["userTools"] || [];
         WindowModel.amapKey = WindowModel.config["amapKey"];
         WindowModel.amapSecurityJsCode = WindowModel.config["amapSecurityJsCode"];
         WindowModel.title = WindowModel.config["title"] || 'Erupt Framework';
@@ -65,6 +68,14 @@ export class WindowModel {
 interface EventCycle {
     load: (e?: any) => void,
     unload: (e?: any) => void,
+}
+
+export interface UserTool {
+    icon:string;
+
+    text: string;
+
+    click(event: Event): void;
 }
 
 

--- a/src/app/shared/model/window.model.ts
+++ b/src/app/shared/model/window.model.ts
@@ -87,7 +87,7 @@ export interface CustomerTool {
 
     mobileHidden: boolean;
 
-    render: string;
+    render: string | Function;
 
     load(): void;
 

--- a/src/app/shared/model/window.model.ts
+++ b/src/app/shared/model/window.model.ts
@@ -18,6 +18,8 @@ export class WindowModel {
 
     public static logoPath: string;
 
+    public static logoFoldPath: string;
+
     public static loginLogoPath: string;
 
     public static logoText: string;
@@ -37,6 +39,7 @@ export class WindowModel {
         WindowModel.title = WindowModel.config["title"] || 'Erupt Framework';
         WindowModel.desc = WindowModel.config["desc"] || undefined;
         WindowModel.logoPath = WindowModel.config["logoPath"] === '' ? null : (WindowModel.config["logoPath"] || "erupt.svg");
+        WindowModel.logoFoldPath = WindowModel.config["logoFoldPath"] || WindowModel.logoPath;
         WindowModel.loginLogoPath = WindowModel.config["loginLogoPath"] === '' ? null : (WindowModel.config["loginLogoPath"] || WindowModel.logoPath);
         WindowModel.logoText = WindowModel.config["logoText"] || "";
         WindowModel.registerPage = WindowModel.config["registerPage"] || undefined; //注册页面地址
@@ -72,6 +75,8 @@ export interface CustomerTool {
     text: string;
 
     mobileHidden: boolean;
+
+    render: string;
 
     load(): void;
 

--- a/src/app/shared/service/data.service.ts
+++ b/src/app/shared/service/data.service.ts
@@ -210,6 +210,16 @@ export class DataService {
         });
     }
 
+    findChoiceItemFilter(eruptName: string, field: string, data: object, eruptParentName?: string): Observable<VL[]> {
+        return this._http.post(RestPath.component + "/choice-item-filter/" + eruptName + "/" + field, data, {}, {
+            observe: "body",
+            headers: {
+                erupt: eruptName,
+                eruptParent: eruptParentName || ''
+            }
+        });
+    }
+
     findTagsItem(eruptName: string, field: string, eruptParentName?: string): Observable<string[]> {
         return this._http.get<string[]>(RestPath.component + "/tags-item/" + eruptName + "/" + field, null, {
             observe: "body",

--- a/src/erupt.i18n.csv
+++ b/src/erupt.i18n.csv
@@ -3,6 +3,7 @@ Y,是,是,Yes,est,はい、,네,эт,es
 N,否,否,No,oui,いいえ、,아니오,нет,si
 finish,完成,完成,Finish,L’achèvement du,完了,완성,законч,completar
 global.today,今天,今天,Today,aujourd’hui,今日,오늘,сегодн,hoy
+global.yesterday,昨天,昨天,Yesterday,Hier,昨日（きのう）,어제,Вчера,Ieri
 global.date.last_7_day,近7天,近7天,Last  7 day,7 derniers jours,7日近くです,최근 7일,Почти семь дней.,Últimos 7 días
 global.date.last_30_day,近30天,近30天,Last  30 day,Près de 30 jours,30日近くです,근 30일,Почти 30 дней.,Casi 30 días
 global.date.this_month,本月,本月,This month,Ce mois-ci,今の月,지난,месяц,Este mes


### PR DESCRIPTION
🧩 时间快捷选择支持昨日
🧩 EruptDao LambadQuery支持 not in
🧩 slider 组件支持 0.x 步进，调整step参数类型为float
🧩 Layout 注解增加 [tableWidth](https://www.yuque.com/erupts/erupt/abgsh10xr7nrkzga#grAm1) 配置，用于手动定义表格的总宽度
🧩 Choice 组件增强联动能力易用性，[Choice 组件联动机制从前端联动改为后端联动](https://www.yuque.com/erupts/erupt/pd5xn9#S1jRs)
🌟 MultiChoice 组件支持[联动](https://www.yuque.com/erupts/erupt/hvd6dk055wtspd0b#rrSly)能力
🌟 erupt-jap 支持多对一对象[ with 语法的 lambda 查询 ](https://www.yuque.com/erupts/erupt/wgc30d#E78b8) 
🌟 [开源erupt-ai模块](https://www.yuque.com/erupts/erupt/qsk71q5zyy3segr6)
● 支持多模型：ChatGpt、Olama、DeepSeek、GML、Gemini、Moonshot等
● 支持智能体、Function Call、交互式聊天